### PR TITLE
add edits to imp facts-total

### DIFF
--- a/experiments/my_total_exp/experiment-compose.yaml
+++ b/experiments/my_total_exp/experiment-compose.yaml
@@ -1,0 +1,303 @@
+services:
+   fair-temperature:
+      image: ghcr.io/fact-sealevel/fair-temperature:0.2.1
+      command:
+         - "--pipeline-id=aaa"
+         - "--nsamps=200"
+         - "--seed=1234"
+         - "--scenario=ssp585"
+         - "--cyear-start=1850"
+         - "--cyear-end=1900"
+         - "--smooth-win=19"
+         - "--rcmip-file=/mnt/module_specific_in/rcmip/rcmip-emissions-annual-means-v5-1-0.csv"
+         - "--param-file=/mnt/module_specific_in/parameters/fair_ar6_climate_params_v4.0.nc"
+         - "--output-oceantemp-file=/mnt/out/fair-temperature/oceantemp.nc"
+         - "--output-climate-file=/mnt/out/fair-temperature/climate.nc"
+         - "--output-ohc-file=/mnt/out/fair-temperature/ohc.nc"
+         - "--output-gsat-file=/mnt/out/fair-temperature/gsat.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/fair-temperature:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+   bamber19-icesheets:
+      image: ghcr.io/fact-sealevel/bamber19-icesheets:0.1.0
+      command:
+         - "--pipeline-id=aaa"
+         - "--nsamps=200"
+         - "--rngseed=1234"
+         - "--scenario=ssp585"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--baseyear=2005"
+         - "--fingerprint-dir=/mnt/general_in/FPRINT"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--replace=1"
+         - "--chunksize=50"
+         - "--climate-data-file=/mnt/out/fair-temperature/climate.nc"
+         - "--slr-proj-mat-file=/mnt/module_specific_in/SLRProjections190726core_SEJ_full.mat"
+         - "--output-AIS-gslr-file=/mnt/out/bamber19-icesheets/AIS-gslr.nc"
+         - "--output-EAIS-gslr-file=/mnt/out/bamber19-icesheets/EAIS-gslr.nc"
+         - "--output-WAIS-gslr-file=/mnt/out/bamber19-icesheets/WAIS-gslr.nc"
+         - "--output-GIS-gslr-file=/mnt/out/bamber19-icesheets/GIS-gslr.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/bamber19-icesheets:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+      depends_on:
+            fair-temperature:
+               condition: service_completed_successfully
+   deconto21-ais:
+      image: ghcr.io/fact-sealevel/deconto21-ais:latest
+      command:
+         - "--pipeline-id=aaa"
+         - "--scenario=ssp585"
+         - "--nsamps=200"
+         - "--rngseed=1234"
+         - "--baseyear=2005"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--fingerprint-dir=/mnt/general_in/FPRINT"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--replace=True"
+         - "--chunksize=50"
+         - "--input-eais-rcp26-file=/mnt/module_specific_in/dp21_eais_rcp26.nc"
+         - "--input-eais-rcp45-file=/mnt/module_specific_in/dp21_eais_rcp45.nc"
+         - "--input-eais-rcp85-file=/mnt/module_specific_in/dp21_eais_rcp85.nc"
+         - "--input-wais-rcp26-file=/mnt/module_specific_in/dp21_wais_rcp26.nc"
+         - "--input-wais-rcp45-file=/mnt/module_specific_in/dp21_wais_rcp45.nc"
+         - "--input-wais-rcp85-file=/mnt/module_specific_in/dp21_wais_rcp85.nc"
+         - "--output-ais-gslr-file=/mnt/out/deconto21-ais/ais-gslr.nc"
+         - "--output-eais-gslr-file=/mnt/out/deconto21-ais/eais-gslr.nc"
+         - "--output-wais-gslr-file=/mnt/out/deconto21-ais/wais-gslr.nc"
+         - "--output-ais-lslr-file=/mnt/out/deconto21-ais/ais-lslr.nc"
+         - "--output-eais-lslr-file=/mnt/out/deconto21-ais/eais-lslr.nc"
+         - "--output-wais-lslr-file=/mnt/out/deconto21-ais/wais-lslr.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/deconto21-ais:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+   fittedismip-gris:
+      image: ghcr.io/fact-sealevel/fittedismip-gris:0.1.2
+      command:
+         - "--pipeline-id=aaa"
+         - "--scenario=ssp585"
+         - "--nsamps=200"
+         - "--rngseed=1234"
+         - "--baseyear=2005"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--fingerprint-dir=/mnt/general_in/FPRINT"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--tlm-flag=1"
+         - "--cyear-end=2100"
+         - "--chunksize=50"
+         - "--climate-data-file=/mnt/out/fair-temperature/climate.nc"
+         - "--gris-parm-file=/mnt/module_specific_in/FittedParms_GrIS_ALL.csv"
+         - "--wais-parm-file=/mnt/module_specific_in/FittedParms_AIS_WAIS.csv"
+         - "--eais-parm-file=/mnt/module_specific_in/FittedParms_AIS_EAIS.csv"
+         - "--pen-parm-file=/mnt/module_specific_in/FittedParms_AIS_PEN.csv"
+         - "--gris-global-out-file=/mnt/out/fittedismip-gris/gris-global-out.nc"
+         - "--gris-local-out-file=/mnt/out/fittedismip-gris/gris-local-out.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/fittedismip-gris:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+      restart: 'no'
+      depends_on:
+            fair-temperature:
+               condition: service_completed_successfully
+   ipccar5-glaciers:
+      image: ghcr.io/fact-sealevel/ipccar5:0.1.1
+      command:
+         - "glaciers"
+         - "--pipeline-id=aaa"
+         - "--scenario=ssp585"
+         - "--rng-seed=1234"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--start-year=2005"
+         - "--fingerprint-dir=/mnt/general_in/FPRINT"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--refyear-start=1986"
+         - "--refyear-end=2005"
+         - "--end-year=2301"
+         - "--tlm-flag=1"
+         - "--use-gmip=2"
+         - "--nsamps=100"
+         - "--chunksize=20"
+         - "--climate-data-file=/mnt/out/fair-temperature/climate.nc"
+         - "--glacier-fraction-file=/mnt/module_specific_in/glacier_fraction.txt"
+         - "--global-output-file=/mnt/out/ipccar5-glaciers/global-output.nc"
+         - "--local-output-file=/mnt/out/ipccar5-glaciers/local-output.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/ipccar5:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+      depends_on:
+            fair-temperature:
+               condition: service_completed_successfully
+   ipccar5-icesheets:
+      image: ghcr.io/fact-sealevel/ipccar5:0.1.1
+      command:
+         - "icesheets"
+         - "--pipeline-id=aaa"
+         - "--scenario=ssp585"
+         - "--rng-seed=1234"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--start-year=2005"
+         - "--nsamps=200"
+         - "--fingerprint-dir=/mnt/general_in/FPRINT"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--refyear-start=1986"
+         - "--refyear-end=2005"
+         - "--tlm-flag=1"
+         - "--chunksize=20"
+         - "--climate-data-file=/mnt/out/fair-temperature/climate.nc"
+         - "--icesheet-fraction-file=/mnt/module_specific_in/icesheet_fraction.txt"
+         - "--global-gis-output-file=/mnt/out/ipccar5-icesheets/global-gis-output.nc"
+         - "--global-ais-output-file=/mnt/out/ipccar5-icesheets/global-ais-output.nc"
+         - "--global-wais-output-file=/mnt/out/ipccar5-icesheets/global-wais-output.nc"
+         - "--global-eais-output-file=/mnt/out/ipccar5-icesheets/global-eais-output.nc"
+         - "--local-gis-output-file=/mnt/out/ipccar5-icesheets/local-gis-output.nc"
+         - "--local-ais-output-file=/mnt/out/ipccar5-icesheets/local-ais-output.nc"
+         - "--local-wais-output-file=/mnt/out/ipccar5-icesheets/local-wais-output.nc"
+         - "--local-eais-output-file=/mnt/out/ipccar5-icesheets/local-eais-output.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/ipccar5:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+      depends_on:
+            fair-temperature:
+               condition: service_completed_successfully
+   tlm-sterodynamics:
+      image: ghcr.io/fact-sealevel/tlm-sterodynamics:latest
+      command:
+         - "--pipeline-id=aaa"
+         - "--nsamps=200"
+         - "--seed=1234"
+         - "--scenario=ssp585"
+         - "--baseyear=2005"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--no-drift-corr=False"
+         - "--no-correlation=False"
+         - "--climate-data-file=/mnt/out/fair-temperature/climate.nc"
+         - "--model-dir=/mnt/module_specific_in/cmip6"
+         - "--expansion-coefficients-file=/mnt/module_specific_in/scmpy2LM_RCMIP_CMIP6calpm_n18_expcoefs.nc"
+         - "--gsat-rmses-file=/mnt/module_specific_in/scmpy2LM_RCMIP_CMIP6calpm_n17_gsat_rmse.nc"
+         - "--output-gslr-file=/mnt/out/tlm-sterodynamics/gslr.nc"
+         - "--output-lslr-file=/mnt/out/tlm-sterodynamics/lslr.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/tlm-sterodynamics:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+      depends_on:
+            fair-temperature:
+               condition: service_completed_successfully
+   nzinsargps-verticallandmotion:
+      image: ghcr.io/fact-sealevel/nzinsargps-verticallandmotion:0.1.0
+      command:
+         - "--nsamps=200"
+         - "--rngseed=1234"
+         - "--baseyear=2005"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--min-qf=5"
+         - "--use-boprates=1"
+         - "--chunksize=50"
+         - "--input-fname=/mnt/module_specific_in/NZ_2km.txt"
+         - "--output-lslr-file=/mnt/out/nzinsargps-verticallandmotion/lslr.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/nzinsargps-verticallandmotion:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+      restart: 'no'
+   kopp14-verticallandmotion:
+      image: ghcr.io/fact-sealevel/kopp14-verticallandmotion:0.1.0
+      command:
+         - "--pipeline-id=aaa"
+         - "--nsamps=200"
+         - "--rng-seed=1234"
+         - "--baseyear=2005"
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--location-file=/mnt/general_in/location.lst"
+         - "--chunk-size=50"
+         - "--rate-file=/mnt/module_specific_in/bkgdrate-210306.tsv"
+         - "--output-lslr-file=/mnt/out/kopp14-verticallandmotion/lslr.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/out
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs/kopp14-verticallandmotion:/mnt/module_specific_in
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs:/mnt/general_in
+      restart: 'no'
+   facts-total-wf1:
+      image: ghcr.io/fact-sealevel/facts-total:0.1.3
+      command:
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--item=/mnt/total_out/bamber19-icesheets/AIS-gslr.nc"
+         - "--item=/mnt/total_out/bamber19-icesheets/EAIS-gslr.nc"
+         - "--item=/mnt/total_out/bamber19-icesheets/WAIS-gslr.nc"
+         - "--item=/mnt/total_out/bamber19-icesheets/GIS-gslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/ais-gslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/eais-gslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/wais-gslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/ais-lslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/eais-lslr.nc"
+         - "--item=/mnt/total_out/deconto21-ais/wais-lslr.nc"
+         - "--output-path=/mnt/total_out/facts-total-wf1/total.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/total_out
+      restart: 'no'
+      depends_on:
+            bamber19-icesheets:
+               condition: service_completed_successfully
+            deconto21-ais:
+               condition: service_completed_successfully
+   facts-total-wf2:
+      image: ghcr.io/fact-sealevel/facts-total:0.1.3
+      command:
+         - "--pyear-start=2020"
+         - "--pyear-end=2150"
+         - "--pyear-step=10"
+         - "--item=/mnt/total_out/ipccar5-glaciers/global-output.nc"
+         - "--item=/mnt/total_out/ipccar5-glaciers/local-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/global-gis-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/global-ais-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/global-wais-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/global-eais-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/local-gis-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/local-ais-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/local-wais-output.nc"
+         - "--item=/mnt/total_out/ipccar5-icesheets/local-eais-output.nc"
+         - "--item=/mnt/total_out/tlm-sterodynamics/gslr.nc"
+         - "--item=/mnt/total_out/tlm-sterodynamics/lslr.nc"
+         - "--output-path=/mnt/total_out/facts-total-wf2/total.nc"
+      volumes:
+         - /Users/emmamarshall/Desktop/facts_work/facts_v2/facts-experiment-builder/experiments/my_total_exp/data/output:/mnt/total_out
+      restart: 'no'
+      depends_on:
+            ipccar5-glaciers:
+               condition: service_completed_successfully
+            ipccar5-icesheets:
+               condition: service_completed_successfully
+            tlm-sterodynamics:
+               condition: service_completed_successfully

--- a/experiments/my_total_exp/experiment-metadata.yml
+++ b/experiments/my_total_exp/experiment-metadata.yml
@@ -1,0 +1,392 @@
+
+### Experiment metadata YAML file ###
+# This is the main configuration file that describes the specified FACTS experiment. 
+# It is generated with prepopulated keys based on the modules you specified in `setup-new-experiment`. 
+# The values included here are defaults based on the default values for each module specified in /modules/module_name/defaults.yml.
+
+# **How to use this file:**
+# 1. Fill in the desired values for the top-level parameters of the experiment.
+# 2. Specify the location of the input data to be used in this experiment.
+# 3. Specify the location file to be used in this experiment.
+# 4. Review the module-level inputs, options, and outputs to ensure they are correct.
+
+# **IMPORTANT**
+# This file does not 'run' a FACTS experiment, it merely specifies an experiment. Once you have completed filling out this file, run:
+# `uv run generate-compose <experiment_directorY> to generate a Docker Compose file that corresponds to this experiment.
+# Then, run `docker compose -f <compose_file> up` to run the experiment.
+
+experiment_name:
+        my_total_exp
+
+##----- Top-level params -----##
+pipeline-id:
+        # Pipeline ID
+        aaa
+scenario:
+        # Emissions scenario name
+        ssp585
+baseyear:
+        # Base year
+        2005
+pyear_start:
+        # Projection year start
+        2020
+pyear_end:
+        # Projection year end
+        2150
+pyear_step:
+        # Projection year step
+        10
+nsamps:
+        # Number of samples
+        200
+seed:
+        # Random seed to use for sampling
+        1234
+
+##----- Fingerprint params -----##
+fingerprint-dir:
+        # Fingerprint directory
+        FPRINT
+location-file:
+        # Location file
+        location.lst
+
+##----- Modules included in experiment -----##
+temperature_module:
+        fair-temperature
+sealevel_modules:
+        - bamber19-icesheets
+        - deconto21-ais
+        - fittedismip-gris
+        - ipccar5-glaciers
+        - ipccar5-icesheets
+        - tlm-sterodynamics
+        - nzinsargps-verticallandmotion
+        - kopp14-verticallandmotion
+
+##----- Workflows (facts-total) -----##
+workflows:
+  wf1: "bamber19-icesheets,deconto21-ais"
+  wf2: "ipccar5-glaciers,ipccar5-icesheets,tlm-sterodynamics"
+
+##----- Inputs -----##
+module-specific-input-data:
+        # Module-specific input data
+        "/Users/emmamarshall/Desktop/facts_work/facts_v2/data/module-specific-inputs"
+general-input-data:
+        # General input data
+        "/Users/emmamarshall/Desktop/facts_work/facts_v2/data/general-inputs"
+
+##----- Outputs -----##
+output-data-location:
+        # Output path
+        "./experiments/my_total_exp/data/output"
+
+##----- Module-specific inputs, options, and outputs -----##
+fair-temperature:
+  inputs:
+    rcmip_fname:
+      # TO DO ADD HELP TEXT
+      "rcmip/rcmip-emissions-annual-means-v5-1-0.csv"
+    param_fname:
+      # TO DO ADD HELP TEXT
+      "parameters/fair_ar6_climate_params_v4.0.nc"
+  options:
+    # Options inherited from top-level metadata: pipeline-id, nsamps, seed, scenario
+    cyear_start:
+      # TO DO ADD HELP TEXT
+      1850
+    cyear_end:
+      # TO DO ADD HELP TEXT
+      1900
+    smooth_win:
+      # TO DO ADD HELP TEXT
+      19
+  image: "ghcr.io/fact-sealevel/fair-temperature:0.2.1"
+  outputs:
+    output-oceantemp-file: "fair-temperature/oceantemp.nc"
+    output-climate-file: "fair-temperature/climate.nc"
+    output-ohc-file: "fair-temperature/ohc.nc"
+    output-gsat-file: "fair-temperature/gsat.nc"
+bamber19-icesheets:
+  inputs:
+    climate_data_file:
+      # add your climate_data_file here
+      "fair-temperature/climate.nc"
+    slr_proj_mat_file:
+      # add your slr_proj_mat_file here
+      SLRProjections190726core_SEJ_full.mat
+    fingerprint_dir:
+      # add your fingerprint_dir here
+    location_file:
+      # add your location_file here
+  options:
+    # Options inherited from top-level metadata: pipeline-id, nsamps, rngseed, scenario, pyear-start, pyear-end, pyear-step, baseyear
+    replace:
+      # add your replace here
+      1
+    chunksize:
+      # add your chunksize here
+      50
+  image: "ghcr.io/fact-sealevel/bamber19-icesheets:0.1.0"
+  outputs:
+    output-AIS-gslr-file: "bamber19-icesheets/AIS-gslr.nc"
+    output-EAIS-gslr-file: "bamber19-icesheets/EAIS-gslr.nc"
+    output-WAIS-gslr-file: "bamber19-icesheets/WAIS-gslr.nc"
+    output-GIS-gslr-file: "bamber19-icesheets/GIS-gslr.nc"
+deconto21-ais:
+  inputs:
+    input_eais_rcp26_file:
+      # add your input_eais_rcp26_file here
+      dp21_eais_rcp26.nc
+    input_eais_rcp45_file:
+      # add your input_eais_rcp45_file here
+      dp21_eais_rcp45.nc
+    input_eais_rcp85_file:
+      # add your input_eais_rcp85_file here
+      dp21_eais_rcp85.nc
+    input_wais_rcp26_file:
+      # add your input_wais_rcp26_file here
+      dp21_wais_rcp26.nc
+    input_wais_rcp45_file:
+      # add your input_wais_rcp45_file here
+      dp21_wais_rcp45.nc
+    input_wais_rcp85_file:
+      # add your input_wais_rcp85_file here
+      dp21_wais_rcp85.nc
+    location-file:
+      # add your location-file here
+    fingerprint-dir:
+      # add your fingerprint-dir here
+  options:
+    # Options inherited from top-level metadata: pipeline-id, scenario, nsamps, rngseed, baseyear, pyear-start, pyear-end, pyear-step
+    replace:
+      # add your replace here
+      True
+    chunksize:
+      # add your chunksize here
+      50
+  image: "ghcr.io/fact-sealevel/deconto21-ais:latest"
+  outputs:
+    output-ais-gslr-file: "deconto21-ais/ais-gslr.nc"
+    output-eais-gslr-file: "deconto21-ais/eais-gslr.nc"
+    output-wais-gslr-file: "deconto21-ais/wais-gslr.nc"
+    output-ais-lslr-file: "deconto21-ais/ais-lslr.nc"
+    output-eais-lslr-file: "deconto21-ais/eais-lslr.nc"
+    output-wais-lslr-file: "deconto21-ais/wais-lslr.nc"
+fittedismip-gris:
+  inputs:
+    climate_data_file:
+      # TO DO ADD HELP TEXT
+      "fair-temperature/climate.nc"
+    gris_parm_file:
+      # TO DO ADD HELP TEXT
+      FittedParms_GrIS_ALL.csv
+    wais_parm_file:
+      # TO DO ADD HELP TEXT
+      FittedParms_AIS_WAIS.csv
+    eais_parm_file:
+      # TO DO ADD HELP TEXT
+      FittedParms_AIS_EAIS.csv
+    pen_parm_file:
+      # TO DO ADD HELP TEXT
+      FittedParms_AIS_PEN.csv
+  options:
+    # Options inherited from top-level metadata: pipeline-id, scenario, nsamps, rngseed, baseyear, pyear-start, pyear-end, pyear-step
+    tlm_flag:
+      # TO DO ADD HELP TEXT
+      1
+    cyear_start:
+      # TO DO ADD HELP TEXT
+    cyear_end:
+      # TO DO ADD HELP TEXT
+      2100
+    chunksize:
+      # TO DO ADD HELP TEXT
+      50
+    pyear_start:
+      # add your pyear_start here
+      2020
+    pyear_end:
+      # add your pyear_end here
+      2100
+    pyear_step:
+      # add your pyear_step here
+      10
+    baseyear:
+      # add your baseyear here
+      2005
+  image: "ghcr.io/fact-sealevel/fittedismip-gris:0.1.2"
+  outputs:
+    gris-global-out-file: "fittedismip-gris/gris-global-out.nc"
+    gris-local-out-file: "fittedismip-gris/gris-local-out.nc"
+ipccar5-glaciers:
+  inputs:
+    climate_data_file:
+      # NetCDF4/HDF5 file containing surface temperature data (this should be a fair output)
+      "fair-temperature/climate.nc"
+    glacier_fraction_file:
+      # Path to glacier fraction file
+      glacier_fraction.txt
+    fingerprint_dir:
+      # Path to fingerprint directory
+    location_file:
+      # File that contains name, id, lat, and lon of points for localization
+  options:
+    # Options inherited from top-level metadata: pipeline-id, scenario, rng-seed, pyear-start, pyear-end, pyear-step, start-year
+    refyear_start:
+      # Start year for reference period
+      1986
+    refyear_end:
+      # End year for reference period
+      2005
+    end_year:
+      # Year to end the projection (Used in preprocess)
+      2301
+    tlm_flag:
+      # Use the two-layer model data, 1=yes
+      1
+    use_gmip:
+      # Use the GMIP calibration
+      2
+    nsamps:
+      # Total number of samples to generate (replaces 'nmsamps' and 'ntsamps' if provided)
+      100
+    chunksize:
+      # Number of locations to process at a time
+      20
+    start_year:
+      # add your start_year here
+      2005
+  image: "ghcr.io/fact-sealevel/ipccar5:0.1.1"
+  outputs:
+    global-output-file: "ipccar5-glaciers/global-output.nc"
+    local-output-file: "ipccar5-glaciers/local-output.nc"
+ipccar5-icesheets:
+  inputs:
+    climate_data_file:
+      # NetCDF4/HDF5 file containing surface temperature data (this should be a fair output)
+      "fair-temperature/climate.nc"
+    icesheet_fraction_file:
+      # Path to icesheet fraction file
+      icesheet_fraction.txt
+    fingerprint_dir:
+      # Path to fingerprint directory
+    location_file:
+      # File that contains name, id, lat, and lon of points for localization
+  options:
+    # Options inherited from top-level metadata: pipeline-id, scenario, rng-seed, pyear-start, pyear-end, pyear-step, start-year, nsamps
+    refyear_start:
+      # Start year for reference period
+      1986
+    refyear_end:
+      # End year for reference period
+      2005
+    tlm_flag:
+      # Use the two-layer model data, 1=yes
+      1
+    nsamps:
+      # Total number of samples to generate (replaces 'nmsamps' and 'ntsamps' if provided)
+    chunksize:
+      # Number of locations to process at a time
+      20
+    start_year:
+      # add your start_year here
+      2005
+    end_year:
+      # add your end_year here
+      2301
+    use_gmip:
+      # add your use_gmip here
+      2
+  image: "ghcr.io/fact-sealevel/ipccar5:0.1.1"
+  outputs:
+    global-gis-output-file: "ipccar5-icesheets/global-gis-output.nc"
+    global-ais-output-file: "ipccar5-icesheets/global-ais-output.nc"
+    global-wais-output-file: "ipccar5-icesheets/global-wais-output.nc"
+    global-eais-output-file: "ipccar5-icesheets/global-eais-output.nc"
+    local-gis-output-file: "ipccar5-icesheets/local-gis-output.nc"
+    local-ais-output-file: "ipccar5-icesheets/local-ais-output.nc"
+    local-wais-output-file: "ipccar5-icesheets/local-wais-output.nc"
+    local-eais-output-file: "ipccar5-icesheets/local-eais-output.nc"
+tlm-sterodynamics:
+  inputs:
+    climate_data_file:
+      # TO DO ADD HELP TEXT
+      "fair-temperature/climate.nc"
+    location_file:
+      # TO DO ADD HELP TEXT
+    model_dir:
+      # TO DO ADD HELP TEXT
+      "cmip6/"
+    expansion_coefficients_file:
+      # TO DO ADD HELP TEXT
+      scmpy2LM_RCMIP_CMIP6calpm_n18_expcoefs.nc
+    gsat_rmses_file:
+      # TO DO ADD HELP TEXT
+      scmpy2LM_RCMIP_CMIP6calpm_n17_gsat_rmse.nc
+  options:
+    # Options inherited from top-level metadata: pipeline-id, nsamps, seed, scenario, baseyear, pyear-start, pyear-end, pyear-step
+    scenario_dsl:
+      # TO DO ADD HELP TEXT
+      
+    no_drift_corr:
+      # TO DO ADD HELP TEXT
+      False
+    no_correlation:
+      # TO DO ADD HELP TEXT
+      False
+    chunksize:
+      # TO DO ADD HELP TEXT
+    debug:
+      # TO DO ADD HELP TEXT
+  image: "ghcr.io/fact-sealevel/tlm-sterodynamics:latest"
+  outputs:
+    output-gslr-file: "tlm-sterodynamics/gslr.nc"
+    output-lslr-file: "tlm-sterodynamics/lslr.nc"
+nzinsargps-verticallandmotion:
+  inputs:
+    input_fname:
+      # TO DO ADD HELP TEXT
+      NZ_2km.txt
+  options:
+    # Options inherited from top-level metadata: nsamps, rngseed, baseyear, pyear-start, pyear-end, pyear-step
+    min_qf:
+      # TO DO ADD HELP TEXT
+      5
+    use_boprates:
+      # TO DO ADD HELP TEXT
+      1
+    chunksize:
+      # TO DO ADD HELP TEXT
+      50
+  image: "ghcr.io/fact-sealevel/nzinsargps-verticallandmotion:0.1.0"
+  outputs:
+    output-lslr-file: "nzinsargps-verticallandmotion/lslr.nc"
+kopp14-verticallandmotion:
+  inputs:
+    rate_file:
+      # TO DO ADD HELP TEXT
+      bkgdrate-210306.tsv
+    location_file:
+      # TO DO ADD HELP TEXT
+  options:
+    # Options inherited from top-level metadata: pipeline-id, nsamps, rng-seed, baseyear, pyear-start, pyear-end, pyear-step
+    chunk_size:
+      # TO DO ADD HELP TEXT
+      50
+  image: "ghcr.io/fact-sealevel/kopp14-verticallandmotion:0.1.0"
+  outputs:
+    output-lslr-file: "kopp14-verticallandmotion/lslr.nc"
+facts-total:
+  inputs:
+    item:
+      # add your item here
+  options:
+    # Options inherited from top-level metadata: pyear-start, pyear-end, pyear-step
+    name:
+      # add your name here
+  image: "ghcr.io/fact-sealevel/facts-total:0.1.2"
+  outputs:
+    output-path: "facts-total/total.nc"

--- a/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
+++ b/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from typing import Dict, Any
-
+import os
 from facts_experiment_builder.adapters.adapter_utils import (
     get_required_field,
     get_experiment_paths,
@@ -73,12 +73,14 @@ def build_module_service_spec(
 
     module_context = f"{module_name} module"
 
+    #TODO fix this
     if module_yaml_path and module_yaml_path.exists():
         resolved_yaml_path = module_yaml_path
+        #this is total module step/ workflows 
     else:
+        #this is climate + sea level module steps
         project_root = find_project_root(experiment_dir)
         resolved_yaml_path = find_module_yaml_path(module_name, project_root)
-
     module_definition = load_facts_module_from_yaml(resolved_yaml_path)
     module_metadata = get_required_field(metadata, module_name, module_context)
 
@@ -118,16 +120,18 @@ def build_module_service_spec(
         experiment_paths["output_data_location"],
         f"{module_context} (output-data-location)",
     )
-    # Only facts-total workflow services use a shared subdir and optional container base
-    is_facts_total_workflow = (
-        module_name.startswith("facts-total-")
-        or module_metadata.get("_output_subdir") == "facts-total"
-    )
+    # Only facts-total workflow services (names like facts-total-wf1) use a shared output
+    # subdir and optional container base. Other modules are unchanged.
+    is_facts_total_workflow = module_name.startswith("facts-total-")
     if is_facts_total_workflow:
         output_data_location = output_data_partial + "/facts-total"
+        if not Path(output_data_location).exists():
+            os.makedirs(output_data_location, exist_ok=True)
         output_container_base = module_metadata.get("_output_container_base") or "/mnt/total_out/facts-total"
     else:
         output_data_location = output_data_partial + "/" + module_name
+        if not Path(output_data_location).exists():
+            os.makedirs(output_data_location, exist_ok=True)
         output_container_base = None
 
     module_inputs_section = get_required_field(module_metadata, "inputs", module_context)

--- a/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
+++ b/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
@@ -118,7 +118,17 @@ def build_module_service_spec(
         experiment_paths["output_data_location"],
         f"{module_context} (output-data-location)",
     )
-    output_data_location = output_data_partial + "/" + module_name
+    # Only facts-total workflow services use a shared subdir and optional container base
+    is_facts_total_workflow = (
+        module_name.startswith("facts-total-")
+        or module_metadata.get("_output_subdir") == "facts-total"
+    )
+    if is_facts_total_workflow:
+        output_data_location = output_data_partial + "/facts-total"
+        output_container_base = module_metadata.get("_output_container_base") or "/mnt/total_out/facts-total"
+    else:
+        output_data_location = output_data_partial + "/" + module_name
+        output_container_base = None
 
     module_inputs_section = get_required_field(module_metadata, "inputs", module_context)
     options_dict = {}
@@ -135,6 +145,10 @@ def build_module_service_spec(
     inputs_dict = {}
     for key, value in module_inputs_section.items():
         if key == "input_dir":
+            continue
+        if isinstance(value, list):
+            # e.g. facts-total inputs.item: list of container paths (/mnt/out/...)
+            inputs_dict[key] = [str(v).strip() for v in value if v]
             continue
         if isinstance(value, str) or (isinstance(value, dict) and "value" in value):
             actual = (value.get("value", value) if isinstance(value, dict) else value) or ""
@@ -275,6 +289,7 @@ def build_module_service_spec(
         outputs=outputs_dict,
         image=image,
         metadata=metadata,
+        output_container_base=output_container_base,
     )
 
     return ModuleServiceSpec(

--- a/src/facts_experiment_builder/adapters/module_adapter.py
+++ b/src/facts_experiment_builder/adapters/module_adapter.py
@@ -12,6 +12,7 @@ def create_module_service_spec_from_metadata(
     module_name: str,
     module_type: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    module_yaml_path: Optional[Path] = None,
     ):
     """
     Create a single module service spec from experiment metadata.
@@ -21,6 +22,7 @@ def create_module_service_spec_from_metadata(
         module_name: Module name (e.g. 'fair-temperature', 'bamber19-icesheets')
         module_type: Optional category (e.g. 'temperature_module', 'sealevel_module')
         metadata: Optional pre-loaded metadata (if provided, metadata_path is used only for experiment_dir)
+        module_yaml_path: Optional path to module YAML (e.g. for facts-total workflow services)
 
     Returns:
         ModuleServiceSpec
@@ -35,6 +37,7 @@ def create_module_service_spec_from_metadata(
             experiment_dir,
             module_name=module_name,
             module_type=module_type,
+            module_yaml_path=module_yaml_path,
         )
     except Exception as e:
         error_msg = str(e)

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -165,8 +165,11 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
         except Exception as e:
             print(f"⚠ Warning: Failed to create sealevel module '{module_name}': {e}")
     
-    # Create framework modules if specified
+    # Create framework modules if specified (skip "facts-total" when workflows exist; we add per-workflow services below)
+    workflow_dict = metadata.get("workflows") or {}
     for module_name in manifest.get("framework_modules", []):
+        if module_name == "facts-total" and workflow_dict:
+            continue  # facts-total is added once per workflow below
         try:
             module = create_module_service_spec_from_metadata(
                 metadata_path,
@@ -220,10 +223,71 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
             temperature_service_name=temperature_module_name
         )
         services[service_name] = compose_service
-    
+
+    # Add one facts-total service per workflow (after sealevel services)
+    if workflow_dict:
+        project_root = find_project_root(experiment_dir)
+        facts_total_yaml_path = find_module_yaml_path("facts-total", project_root)
+        with open(facts_total_yaml_path, "r") as f:
+            facts_total_config = yaml.safe_load(f) or {}
+        facts_total_image = facts_total_config.get(
+            "container_image", "ghcr.io/fact-sealevel/facts-total:v0.1.2"
+        )
+        for workflow_name, module_list_str in workflow_dict.items():
+            workflow_modules = [
+                m.strip() for m in module_list_str.split(",") if m.strip()
+            ]
+            # Collect output paths from metadata for modules in this workflow
+            item_paths = []
+            for mod in workflow_modules:
+                out_section = metadata.get(mod, {}) or {}
+                if not isinstance(out_section, dict):
+                    continue
+                outputs = out_section.get("outputs") or {}
+                if not isinstance(outputs, dict):
+                    continue
+                for v in outputs.values():
+                    if isinstance(v, dict) and "value" in v:
+                        p = v.get("value") or ""
+                    elif isinstance(v, str):
+                        p = v
+                    else:
+                        continue
+                    if p and isinstance(p, str):
+                        item_paths.append(f"/mnt/total_out/{p.strip()}")
+            service_name = f"facts-total-{workflow_name}"
+            synthetic_section = {
+                "inputs": {"item": item_paths},
+                "outputs": {"output-path": f"{workflow_name}_total.nc"},
+                "options": {},
+                "fingerprint_params": {},
+                "image": facts_total_image,
+                "_output_subdir": "facts-total",
+                "_output_container_base": "/mnt/total_out/facts-total",
+            }
+            metadata_copy = dict(metadata)
+            metadata_copy[service_name] = synthetic_section
+            try:
+                wf_module = create_module_service_spec_from_metadata(
+                    metadata_path,
+                    module_name=service_name,
+                    module_type="framework_module",
+                    metadata=metadata_copy,
+                    module_yaml_path=facts_total_yaml_path,
+                )
+                compose_svc = wf_module.generate_compose_service()
+                compose_svc["depends_on"] = {
+                    mod: {"condition": "service_completed_successfully"}
+                    for mod in workflow_modules
+                }
+                services[service_name] = compose_svc
+                print(f"✓ Created {service_name} workflow service")
+            except Exception as e:
+                print(f"⚠ Warning: Failed to create workflow service '{service_name}': {e}")
+
     # Step 5: Build complete Docker Compose file as dict
     compose_dict = {
         "services": services
     }
-    
+
     return compose_dict

--- a/src/facts_experiment_builder/application/setup_new_experiment.py
+++ b/src/facts_experiment_builder/application/setup_new_experiment.py
@@ -115,9 +115,12 @@ def init_new_experiment(
     seed: int = None,
     location_file: str = None,
     fingerprint_dir: str = None,
+    workflow_dict: Dict[str, str] = None,
+    module_specific_inputs: str = None,
+    general_inputs: str = None,
     ) -> FactsExperiment:
     """
-    Create a new FactsExperiment from CLI inputs 
+    Create a new FactsExperiment from CLI inputs
     Uses FactsExperiment.create_new_experiment_obj with dependencies from this module.
     """
     return FactsExperiment.create_new_experiment_obj(
@@ -137,6 +140,9 @@ def init_new_experiment(
         seed=seed,
         location_file=location_file,
         fingerprint_dir=fingerprint_dir,
+        workflow_dict=workflow_dict,
+        module_specific_input_data=module_specific_inputs,
+        general_input_data=general_inputs,
         create_metadata_bundle=create_metadata_bundle,
         format_module_from_definition=format_module_from_definition,
         load_facts_module_by_name=load_facts_module_by_name,

--- a/src/facts_experiment_builder/cli/generate_compose_cli.py
+++ b/src/facts_experiment_builder/cli/generate_compose_cli.py
@@ -11,7 +11,6 @@ from facts_experiment_builder.infra.path_manager import (
 )
 from facts_experiment_builder.infra.write_compose import (
     make_compose_yaml,
-    format_compose_yaml,
     write_compose_yaml,
 )
 import logging
@@ -61,9 +60,8 @@ def main(
 
  
     yaml_content = make_compose_yaml(content_dict=compose_dict)
-    formatted_content = format_compose_yaml(content=yaml_content)
     write_compose_yaml(
-        compose_content=formatted_content, 
+        compose_content=yaml_content,
         output_path=output_path,
     )
 

--- a/src/facts_experiment_builder/cli/parsers.py
+++ b/src/facts_experiment_builder/cli/parsers.py
@@ -1,0 +1,20 @@
+"""CLI input parsers: translate raw option strings into values for the application layer."""
+
+from typing import List, Optional
+
+
+def parse_comma_separated_modules(raw: Optional[str]) -> List[str]:
+    """Parse a comma-separated string of module names into a list of non-empty strings.
+
+    Intended for options like --sealevel-modules and --framework-modules.
+    None or empty string yields an empty list. Whitespace around each name is stripped.
+
+    Args:
+        raw: Comma-separated module names, or None.
+
+    Returns:
+        List of stripped, non-empty module name strings.
+    """
+    if raw is None or not raw.strip():
+        return []
+    return [m.strip() for m in raw.split(",") if m.strip()]

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -99,9 +99,21 @@ logger = logging.getLogger(__name__)
     help="Name of directory holding GRD fingerprint data",
     default="FPRINT"
 )
+@click.option("--module-specific-inputs",
+    type=str,
+    required=False,
+    default=None,
+    help="Path to module-specific input data (written to experiment metadata)"
+)
+@click.option("--general-inputs",
+    type=str,
+    required=False,
+    default=None,
+    help="Path to general input data (written to experiment metadata)"
+)
 def main(
-    experiment_name, 
-    temperature_module, 
+    experiment_name,
+    temperature_module,
     sealevel_modules,
     framework_modules,
     extremesealevel_module,
@@ -115,13 +127,58 @@ def main(
     seed,
     location_file,
     fingerprint_dir,
+    module_specific_inputs,
+    general_inputs,
 ):
     """Create a new experiment directory with template files using Jinja2 templating.
     """
 
     # Parse comma-separated sealevel modules into a list
-    sealevel_modules_list = [m.strip() for m in sealevel_modules.split(',') if m.strip()]
-    
+    sealevel_modules_list = [m.strip() for m in sealevel_modules.split(",") if m.strip()]
+    # Parse comma-separated framework modules into a list
+    framework_modules_list = (
+        [m.strip() for m in framework_modules.split(",") if m.strip()]
+        if framework_modules
+        else None
+    )
+
+    # If framework includes facts-total, collect workflows interactively
+    workflow_dict = None
+    if framework_modules_list:
+        normalized_framework = [
+            m.replace(" ", "-").replace("_", "-").strip().lower()
+            for m in framework_modules_list
+        ]
+        if "facts-total" in normalized_framework:
+            workflow_dict = {}
+            first = True
+            while True:
+                if first:
+                    workflow_name = click.prompt(
+                        "Enter a name for your first workflow, ex. wf1",
+                        type=str,
+                        default="wf1",
+                    )
+                    first = False
+                else:
+                    workflow_name = click.prompt(
+                        "Enter a name for this workflow",
+                        type=str,
+                    )
+                workflow_name = workflow_name.strip() or "wf"
+                module_list_str = click.prompt(
+                    "Enter the names of the modules to include in this workflow. "
+                    "Modules should be separated by commas with no spaces between words",
+                    type=str,
+                )
+                workflow_dict[workflow_name] = module_list_str.strip()
+                if not click.confirm(
+                    "Would you like to enter another workflow?",
+                    default=False,
+                ):
+                    break
+            click.echo(f"  Workflows: {workflow_dict}")
+
     # Step 1: Create experiment directory and sub-directories
     click.echo("Step 1: Creating experiment directory and sub-directories...")
     module_names = [temperature_module] + sealevel_modules_list
@@ -135,7 +192,7 @@ def main(
     click.echo(temp_module_message)
     sealevel_modules_message = f"  Sea level modules: {sealevel_modules_list}"
     click.echo(sealevel_modules_message)
-    framework_modules_message = f"  Framework modules: {framework_modules}"
+    framework_modules_message = f"  Framework modules: {framework_modules_list}"
     click.echo(framework_modules_message)
     extremesealevel_module_message = f"  Extreme sea level module: {extremesealevel_module}"
     click.echo(extremesealevel_module_message)
@@ -152,7 +209,7 @@ def main(
         experiment_name=experiment_name,
         temperature_module=temperature_module,
         sealevel_modules=sealevel_modules_list,
-        framework_modules=framework_modules,
+        framework_modules=framework_modules_list,
         extremesealevel_module=extremesealevel_module,
         experiment_path=experiment_path,
         pipeline_id=pipeline_id,
@@ -165,6 +222,9 @@ def main(
         seed=seed,
         location_file=location_file,
         fingerprint_dir=fingerprint_dir,
+        workflow_dict=workflow_dict,
+        module_specific_inputs=module_specific_inputs,
+        general_inputs=general_inputs,
     )
     
     # Step 3: Populate experiment with defaults from defaults.yml files

--- a/src/facts_experiment_builder/core/experiment/facts_experiment.py
+++ b/src/facts_experiment_builder/core/experiment/facts_experiment.py
@@ -1,6 +1,6 @@
 """In-memory representation of an experiment (analogous to experiment-metadata.yml)."""
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Callable
+from typing import Dict, Any, List, Optional, Callable, Union
 
 from facts_experiment_builder.infra.path_manager import find_project_root
 
@@ -42,8 +42,9 @@ class FactsExperiment:
         manifest: Dict[str, Any],
         paths: Dict[str, Any],
         fingerprint_params: Dict[str, Any],
-        module_sections: Dict[str, Dict[str, Any]],
+        module_sections: Dict[str, Union[Dict[str, Any], Any]],
         extra: Optional[Dict[str, Any]] = None,
+        workflows: Optional[Dict[str, str]] = None,
         ):
         self._experiment_name = experiment_name
         self._top_level_params = dict(top_level_params)
@@ -52,6 +53,7 @@ class FactsExperiment:
         self._fingerprint_params = dict(fingerprint_params)
         self._module_sections = dict(module_sections)
         self._extra = dict(extra) if extra is not None else {}
+        self._workflows = dict(workflows) if workflows is not None else {}
 
         # Optional validation, e.g. require manifest keys
         if "temperature_module" not in self._manifest:
@@ -102,6 +104,11 @@ class FactsExperiment:
     def extra(self) -> Dict[str, Any]:
         return self._extra
 
+    @property
+    def workflows(self) -> Dict[str, str]:
+        """Workflows for facts-total: workflow name -> comma-separated module list."""
+        return self._workflows
+
     @classmethod
     def from_metadata_dict(cls, metadata: Dict[str, Any]) -> "FactsExperiment":
         """Build a FactsExperiment from the metadata dict shape (e.g. from YAML)."""
@@ -143,6 +150,11 @@ class FactsExperiment:
         excluded = set(TOP_LEVEL_PARAM_KEYS) | set(FINGERPRINT_PARAM_KEYS) | set(MANIFEST_KEYS) | set(PATH_KEYS_PRIMARY)
         excluded |= set().union(*(PATH_KEYS_ALTERNATIVES.get(k, []) for k in PATH_KEYS_PRIMARY))
         excluded.add("experiment_name")
+        excluded.add("workflows")
+
+        workflows = metadata.get("workflows")
+        if not isinstance(workflows, dict):
+            workflows = {}
 
         module_sections = {
             k: v for k, v in metadata.items()
@@ -153,6 +165,7 @@ class FactsExperiment:
             k: v for k, v in metadata.items()
             if k not in top_level_params and k not in manifest and k not in paths_normalized
             and k not in fingerprint_params and k not in module_sections and k != "experiment_name"
+            and k != "workflows"
         }
 
         return cls(
@@ -163,6 +176,7 @@ class FactsExperiment:
             fingerprint_params=fingerprint_params,
             module_sections=module_sections,
             extra=extra,
+            workflows=workflows,
         )
 
     @classmethod
@@ -175,6 +189,9 @@ class FactsExperiment:
         extremesealevel_module: str = None,
         experiment_path: Path = None,
         *,
+        workflow_dict: Optional[Dict[str, str]] = None,
+        module_specific_input_data: Optional[str] = None,
+        general_input_data: Optional[str] = None,
         pipeline_id: Optional[str] = None,
         scenario: Optional[str] = None,
         baseyear: Optional[int] = None,
@@ -195,8 +212,11 @@ class FactsExperiment:
         Create a new experiment from template/CLI inputs.
         Dependencies are injected to avoid circular imports (call from application layer).
         """
-        #First, create dict and fill with top level param keys 
-        #and their clues/values from top_level_param_clues 
+        # Normalize framework_modules to list (CLI may pass comma-separated string)
+        if framework_modules is not None and isinstance(framework_modules, str):
+            framework_modules = [m.strip() for m in framework_modules.split(",") if m.strip()] or None
+        # First, create dict and fill with top level param keys
+        # and their clues/values from top_level_param_clues
         # TODO top_level_param_clues currently hardcoded in setup_new_experiment
         # need to fix this. others are hardcoded at top of this script.
 
@@ -212,10 +232,14 @@ class FactsExperiment:
             "seed": create_metadata_bundle(top_level_param_clues.get("seed", "Random seed to use for sampling"), seed),
             "temperature_module": temperature_module,
             "sealevel_modules": sealevel_modules if len(sealevel_modules) > 1 else (sealevel_modules[0] if sealevel_modules else []),
-            "framework_modules": framework_modules ,
-            "esl_modules": extremesealevel_module ,
-            "module-specific-input-data": create_metadata_bundle("Module-specific input data"),
-            "general-input-data": create_metadata_bundle("General input data"),
+            "framework_modules": framework_modules,
+            "esl_modules": extremesealevel_module,
+            "module-specific-input-data": create_metadata_bundle(
+                "Module-specific input data", module_specific_input_data
+            ),
+            "general-input-data": create_metadata_bundle(
+                "General input data", general_input_data
+            ),
             "location-file": create_metadata_bundle("Location file", location_file),
             "fingerprint-dir": create_metadata_bundle("Fingerprint directory", fingerprint_dir),
             "output-data-location": create_metadata_bundle(
@@ -254,6 +278,8 @@ class FactsExperiment:
                     metadata[mod] = format_module_from_definition(mod_def)
                 except Exception:
                     pass
+        if workflow_dict:
+            metadata["workflows"] = workflow_dict
         # Remove None values but preserve comment keys
         def remove_none(d: Any) -> Any:
             if isinstance(d, dict):

--- a/src/facts_experiment_builder/core/module/module_service_spec.py
+++ b/src/facts_experiment_builder/core/module/module_service_spec.py
@@ -38,6 +38,7 @@ class ModuleServiceSpecComponents:
     outputs: Dict[str, Any]
     image: ModuleContainerImage
     metadata: Dict[str, Any]
+    output_container_base: Optional[str] = None
     
 class ModuleServiceSpec:
     """Has all information needed to run a module and slot into an experiment implementation (e.g. one compose service).
@@ -107,11 +108,12 @@ class ModuleServiceSpec:
             if value is not None:
                 command_args.append(f"--{arg_spec['name']}={value}")
         
-        # Process fingerprint params
-        for arg_spec in arguments_config.get('fingerprint_params', []):
-            value = self._process_argument(arg_spec)
-            if value is not None:
-                command_args.append(f"--{arg_spec['name']}={value}")
+        if not "facts-total" in self.module_name:
+            # Process fingerprint params
+            for arg_spec in arguments_config.get('fingerprint_params', []):
+                value = self._process_argument(arg_spec)
+                if value is not None:
+                    command_args.append(f"--{arg_spec['name']}={value}")    
         # Process options
         for arg_spec in arguments_config.get('options', []):
             value = self._process_argument(arg_spec)
@@ -248,9 +250,15 @@ class ModuleServiceSpec:
 
         container_path = (mount.get('container_path') or '').rstrip('/')
         volume = mount.get('volume', '')
+        filename = Path(value).name
         if volume == 'output' and container_path:
+            output_container_base = getattr(
+                self.components, 'output_container_base', None
+            ) or None
+            if output_container_base:
+                base = (output_container_base or '').rstrip('/')
+                return f"{base}/{filename}"
             base = f"{container_path}/{self.components.module_name}"
-            filename = Path(value).name
             return f"{base}/{filename}"
         return value
 

--- a/src/facts_experiment_builder/infra/write_experiment_metadata.py
+++ b/src/facts_experiment_builder/infra/write_experiment_metadata.py
@@ -54,6 +54,14 @@ experiment_name:
 {% endif %}
 {% endfor %}
 
+##----- Workflows (facts-total) -----##
+{% if experiment.workflows %}
+workflows:
+{% for wf_name, wf_modules in experiment.workflows.items() %}
+  {{ wf_name }}: "{{ wf_modules }}"
+{% endfor %}
+{% endif %}
+
 ##----- Inputs -----##
 {% for key in inputs %}
 {% if key in experiment.paths %}

--- a/src/facts_experiment_builder/resources/configs/facts_total_module.yaml
+++ b/src/facts_experiment_builder/resources/configs/facts_total_module.yaml
@@ -5,7 +5,7 @@
 # corresponding containerized facts module repository and be generated semi programmatically.
 
 module_name: "facts-total"
-container_image: "ghcr.io/fact-sealevel/facts-total:v0.1.2"
+container_image: "ghcr.io/fact-sealevel/facts-total:0.1.3"
 climate_file_required: false
 
 # Argument specifications


### PR DESCRIPTION
This is a PR to get facts-total working in the experiment builder. its not quite working yet, there is some sort of mount / permissions issue when writing the totaled output of a workflow that i didn't have time to fix:
```shell
facts-total-wf2-1                |   File "src/netCDF4/_netCDF4.pyx", line 2517, in netCDF4._netCDF4.Dataset.__init__
facts-total-wf2-1                |   File "src/netCDF4/_netCDF4.pyx", line 2154, in netCDF4._netCDF4._ensure_nc_success
facts-total-wf2-1                | PermissionError: [Errno 13] Permission denied: '/mnt/total_out/facts-total-wf2/total.nc'
facts-total-wf2-1 exited with code 1
```

There is more detail on how the cli interface is modified to handle facts-total and workflows [here](https://github.com/fact-sealevel/task-board/issues/5)