### PR TITLE
Fix find project root

### DIFF
--- a/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
+++ b/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
@@ -13,7 +13,6 @@ from facts_experiment_builder.infra.path_utils import (
     resolve_output_path,
     build_module_input_paths,
     build_module_output_paths,
-    find_project_root,
 )
 
 from facts_experiment_builder.core.module.module_service_spec import (
@@ -106,7 +105,7 @@ def build_module_service_spec(
         # this is total module step/ workflows
     else:
         # this is climate + sea level module steps
-        project_root = find_project_root(experiment_dir)
+        project_root = Path.cwd()
         resolved_yaml_path = find_module_yaml_path(module_name, project_root)
     module_definition = load_facts_module_from_yaml(resolved_yaml_path)
     module_metadata = get_required_field(metadata, module_name, module_context)

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -25,7 +25,7 @@ from facts_experiment_builder.core.workflow.workflow import (
     workflows_from_metadata,
 )
 from facts_experiment_builder.infra.path_manager import find_module_yaml_path
-from facts_experiment_builder.infra.path_utils import find_project_root, expand_path
+from facts_experiment_builder.infra.path_utils import expand_path
 from facts_experiment_builder.infra.experiment_loader import load_experiment_metadata
 
 
@@ -41,7 +41,7 @@ def _module_requires_climate_file(module_name: str, experiment_dir: Path) -> boo
         True if climate_file_required is True in module YAML, False otherwise
     """
     try:
-        project_root = find_project_root(experiment_dir)
+        project_root = Path.cwd()
         module_yaml_path = find_module_yaml_path(module_name, project_root)
         with open(module_yaml_path, "r") as f:
             module_config = yaml.safe_load(f) or {}
@@ -349,7 +349,7 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
 
     # Add one facts-total service per workflow (after sealevel services)
     if workflows:
-        project_root = find_project_root(experiment_dir)
+        project_root = Path.cwd()
         facts_total_yaml_path = find_module_yaml_path("facts-total", project_root)
         with open(facts_total_yaml_path, "r") as f:
             facts_total_config = yaml.safe_load(f) or {}

--- a/src/facts_experiment_builder/application/setup_new_experiment.py
+++ b/src/facts_experiment_builder/application/setup_new_experiment.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from facts_experiment_builder.infra.path_utils import find_project_root
 from facts_experiment_builder.core.module.facts_module import (
     FactsModule,
 )
@@ -148,7 +147,6 @@ def init_new_experiment(
         create_metadata_bundle=create_metadata_bundle,
         format_module_from_definition=format_module_from_definition,
         load_facts_module_by_name=load_facts_module_by_name,
-        find_project_root=find_project_root,
         top_level_param_clues=TOP_LEVEL_PARAM_CLUES,
     )
 
@@ -164,7 +162,7 @@ def populate_experiment_defaults(experiment: FactsExperiment, module_name: str) 
         return
     module_def = None
     try:
-        project_root = find_project_root()
+        project_root = Path.cwd()
         module_def = load_facts_module_by_name(module_name, project_root)
     except FileNotFoundError as e:
         # Module YAML or project root not found; continue with module_def=None

--- a/src/facts_experiment_builder/core/experiment/facts_experiment.py
+++ b/src/facts_experiment_builder/core/experiment/facts_experiment.py
@@ -245,7 +245,6 @@ class FactsExperiment:
         create_metadata_bundle: Callable[[str, Any], Dict[str, Any]],
         format_module_from_definition: Callable[[Any], Dict[str, Any]],
         load_facts_module_by_name: Callable[[str, Path], Any],
-        find_project_root: Callable[[], Path],
         top_level_param_clues: Dict[str, str],
     ) -> "FactsExperiment":
         """
@@ -313,8 +312,7 @@ class FactsExperiment:
                 f"./experiments/{experiment_name}/data/output",
             ),
         }
-        # Find project root (dir w/ pyproject.toml)
-        project_root = find_project_root()
+        project_root = Path.cwd()
         # Load the module definition files for the specified temperature module, if any
         # uses fn from facts_module.py
         if temperature_module and temperature_module.upper() != "NONE":

--- a/src/facts_experiment_builder/infra/experiment_manager.py
+++ b/src/facts_experiment_builder/infra/experiment_manager.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import List
-from facts_experiment_builder.infra.path_manager import find_project_root
 
 
 def resolve_experiment_directory_path(
@@ -8,7 +7,7 @@ def resolve_experiment_directory_path(
     project_root: Path = None,
 ) -> Path:
     if project_root is None:
-        project_root = find_project_root()
+        project_root = Path.cwd()
 
     experiment_directory = project_root / "experiments" / experiment_name
     return experiment_directory

--- a/src/facts_experiment_builder/infra/path_manager.py
+++ b/src/facts_experiment_builder/infra/path_manager.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Optional
 from facts_experiment_builder.resources import get_module_configs_dir
-from facts_experiment_builder.infra.path_utils import find_project_root
 
 
 def get_module_defaults_path(module_name: str) -> Optional[Path]:
@@ -63,7 +62,7 @@ def find_module_yaml_path(module_name: str, project_root: Path) -> Path:
 
 def find_experiment_metadata_file(experiment_name: str):
     # Resolve path to experiment directory
-    project_root = find_project_root()
+    project_root = Path.cwd()
     experiment_dir = project_root / "experiments" / experiment_name
 
     if not experiment_dir.exists():

--- a/src/facts_experiment_builder/infra/path_utils.py
+++ b/src/facts_experiment_builder/infra/path_utils.py
@@ -129,51 +129,6 @@ def build_module_output_paths(
         )
     return ModuleOutputPaths(output_dir=output_dir, output_type=output_type)
 
-
-def find_project_root(start_path: Path = None) -> Path:
-    """
-    Find the project root by looking for pyproject.toml.
-
-    Searches upward from start_path (or cwd). If not found, falls back to
-    searching from this file's directory so setup remains robust when run
-    from arbitrary cwds.
-
-    Args:
-        start_path: Path to start searching from (defaults to current working directory)
-
-    Returns:
-        Path to project root (directory containing pyproject.toml)
-
-    Raises:
-        FileNotFoundError: If pyproject.toml is not found
-    """
-    if start_path is None:
-        start_path = Path.cwd()
-    else:
-        start_path = Path(start_path).resolve()
-
-    current = start_path
-    while current != current.parent:
-        pyproject_path = current / "pyproject.toml"
-        if pyproject_path.exists():
-            return current
-        current = current.parent
-
-    # Fallback: search from this file's location
-    script_path = Path(__file__).resolve().parent
-    current = script_path
-    while current != current.parent:
-        pyproject_path = current / "pyproject.toml"
-        if pyproject_path.exists():
-            return current
-        current = current.parent
-
-    raise FileNotFoundError(
-        f"Could not find pyproject.toml starting from {start_path}. "
-        "Please run from within the project directory."
-    )
-
-
 def is_general_input(field_name: str) -> bool:
     """
     Determine if an input field is a general input (shared across modules).

--- a/tests/test_generate_compose.py
+++ b/tests/test_generate_compose.py
@@ -12,10 +12,6 @@ def test_module_requires_climate_file_false_when_key_false(tmp_path: Path):
 
     with (
         patch(
-            "facts_experiment_builder.application.generate_compose.find_project_root",
-            return_value=tmp_path,
-        ),
-        patch(
             "facts_experiment_builder.application.generate_compose.find_module_yaml_path",
             return_value=module_yaml,
         ),
@@ -30,10 +26,6 @@ def test_module_requires_climate_file_true_when_key_true(tmp_path: Path):
     module_yaml.write_text("climate_file_required: true \n")
 
     with (
-        patch(
-            "facts_experiment_builder.application.generate_compose.find_project_root",
-            return_value=tmp_path,
-        ),
         patch(
             "facts_experiment_builder.application.generate_compose.find_module_yaml_path",
             return_value=module_yaml,


### PR DESCRIPTION
This PR changes how the file system code that creates a new experiment directory and reads/writes experiment files works so that the application can be run from anywhere and the pkg doesn't need to be cloned locally. 
- Initially, the file system handling relied on a project root containing a `pyproject.toml` file. 
- Now, the program treats wherever it is run from as the project root