### PR TITLE
Many changes related to `setup-new-experiment` CLI command and making use of module registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ facts-experiment-builder = "facts_experiment_builder.cli.cli:main"
 setup-new-experiment = "facts_experiment_builder.cli.setup_new_experiment_cli:main"
 setup-new-experiment-jinja2 = "facts_experiment_builder.cli.setup_new_experiment_jinja2_cli:main"
 generate-compose = "facts_experiment_builder.cli.generate_compose_cli:main"
+list-modules = "facts_experiment_builder.cli.list_modules_cli:list_modules"
 
 [build-system]
 requires = ["uv_build>=0.8.11,<0.9.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "netcdf4>=1.7.3",
     "pyyaml>=6.0.3",
+    "rich>=14.3.3",
     "xarray>=2025.12.0",
 ]
 

--- a/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
+++ b/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
@@ -40,7 +40,10 @@ _KNOWN_MODULE_NAMES: "Optional[frozenset]" = None
 def _registry_module_names() -> frozenset:
     global _KNOWN_MODULE_NAMES
     if _KNOWN_MODULE_NAMES is None:
-        from facts_experiment_builder.core.registry.module_registry import ModuleRegistry
+        from facts_experiment_builder.core.registry.module_registry import (
+            ModuleRegistry,
+        )
+
         _KNOWN_MODULE_NAMES = frozenset(ModuleRegistry.default().list_modules())
     return _KNOWN_MODULE_NAMES
 

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -359,7 +359,8 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
     if workflows:
         project_root = Path.cwd()
         per_workflow_fw = [
-            m for m in manifest.get("framework_modules", [])
+            m
+            for m in manifest.get("framework_modules", [])
             if _module_is_per_workflow(m)
         ]
         facts_total_name = per_workflow_fw[0] if per_workflow_fw else "facts-total"
@@ -370,7 +371,9 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
             "container_image", "ghcr.io/fact-sealevel/facts-total:v0.1.2"
         )
         for wf_name, wf in workflows.items():
-            for output_type in facts_total_config.get("output_types", ["global", "local"]):
+            for output_type in facts_total_config.get(
+                "output_types", ["global", "local"]
+            ):
                 section = _build_facts_total_section_for_workflow(
                     wf, facts_total_image, output_type
                 )

--- a/src/facts_experiment_builder/cli/list_modules_cli.py
+++ b/src/facts_experiment_builder/cli/list_modules_cli.py
@@ -8,5 +8,6 @@ def list_modules():
     modules = module_registry.list_modules()
     click.echo(f"Modules: {modules}")
 
+    
 if __name__ == "__main__":
     list_modules()

--- a/src/facts_experiment_builder/cli/list_modules_cli.py
+++ b/src/facts_experiment_builder/cli/list_modules_cli.py
@@ -1,6 +1,7 @@
 import click
 from facts_experiment_builder.core.registry import ModuleRegistry
 
+
 @click.command()
 def list_modules():
     """List all modules in the registry. These are all of the modules that can be included in experiments built with facts-experiment-builder."""
@@ -8,6 +9,6 @@ def list_modules():
     modules = module_registry.list_modules()
     click.echo(f"Modules: {modules}")
 
-    
+
 if __name__ == "__main__":
     list_modules()

--- a/src/facts_experiment_builder/cli/list_modules_cli.py
+++ b/src/facts_experiment_builder/cli/list_modules_cli.py
@@ -1,0 +1,12 @@
+import click
+from facts_experiment_builder.core.registry import ModuleRegistry
+
+@click.command()
+def list_modules():
+    """List all modules in the registry. These are all of the modules that can be included in experiments built with facts-experiment-builder."""
+    module_registry = ModuleRegistry.default()
+    modules = module_registry.list_modules()
+    click.echo(f"Modules: {modules}")
+
+if __name__ == "__main__":
+    list_modules()

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -125,65 +125,33 @@ def main(
     general_inputs,
     ):
     """Create a new experiment directory with template files using Jinja2 templating."""
+    console.rule(style="rule", title="Setting up new FACTS experiment")
+    console.print("[primary]Step 1:[/primary] I'm reading the information you provided and making sure everything looks okay...")
 
-    # Parse comma-separated sealevel modules into a list
-    sealevel_modules_list = [
-        m.strip() for m in sealevel_modules.split(",") if m.strip()
-    ]
-    # Parse comma-separated framework modules into a list
-    framework_modules_list = (
-        [m.strip() for m in framework_module.split(",") if m.strip()]
-        if framework_module
-        else None
+    # Parse comma-separated module names into a list
+    temperature_module_list, sealevel_modules_list, framework_modules_list, extremesealevel_module_list = _parse_modules_list(
+        temperature_module,
+        sealevel_modules,
+        framework_module,
+        extremesealevel_module,
     )
-    extremesealevel_module_list = (
-        [m.strip() for m in extremesealevel_module.split(",") if m.strip()]
-        if extremesealevel_module
-        else []
-    )
+    # Combine into a total list of all modules in the experiment
+    total_modules_list = temperature_module_list + sealevel_modules_list + framework_modules_list + extremesealevel_module_list
+
+    # Validate the total list of modules
+    _validate_modules_list(total_modules_list)
 
     # If framework includes facts-total, collect workflows interactively
-    workflow_dict = None
-    if framework_modules_list:
-        normalized_framework = [
-            m.replace(" ", "-").replace("_", "-").strip().lower()
-            for m in framework_modules_list
-        ]
-        if "facts-total" in normalized_framework:
-            workflow_dict = {}
-            first = True
-            while True:
-                if first:
-                    workflow_name = click.prompt(
-                        "Enter a name for your first workflow, ex. wf1",
-                        type=str,
-                        default="wf1",
-                    )
-                    first = False
-                else:
-                    workflow_name = click.prompt(
-                        "Enter a name for this workflow",
-                        type=str,
-                    )
-                workflow_name = workflow_name.strip() or "wf"
-                module_list_str = click.prompt(
-                    "Enter the names of the modules to include in this workflow. "
-                    "Modules should be separated by commas with no spaces between words",
-                    type=str,
-                )
-                workflow_dict[workflow_name] = module_list_str.strip()
-                if not click.confirm(
-                    "Would you like to enter another workflow?",
-                    default=False,
-                ):
-                    break
-            click.echo(f"  Workflows: {workflow_dict}")
+    if framework_modules_list and "facts-total" in framework_modules_list:
+        workflow_dict = _collect_workflows()
+    else:
+        workflow_dict = {}
 
     # Step 2: Create experiment directory and sub-directories
     console.print("[primary]Step 2:[/primary] Creating experiment directory and sub-directories...")
 
     experiment_path = setup_new_experiment_fs(
-        experiment_name=experiment_name, module_names=module_names
+        experiment_name=experiment_name, module_names=total_modules_list
     )
 
     console.print(f"[bold]     Setting up new experiment:[/bold] [secondary]{experiment_name}[/secondary]")

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -5,7 +5,8 @@ This script uses Jinja2-based YAML generation from setup_new_experiment.py.
 """
 
 import click
-import logging
+from rich.console import Console
+from rich.theme import Theme
 from facts_experiment_builder.application.setup_new_experiment import (
     setup_new_experiment_fs,
     init_new_experiment,
@@ -20,8 +21,20 @@ from facts_experiment_builder.core.experiment.module_name_validation import (
 )
 from facts_experiment_builder.core.registry import ModuleRegistry
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+# Mid-range lapaz stops — visible on both light and dark terminals
+# Avoids the near-black (#190B35) and near-white (#F9F3C5) extremes
+lapaz_theme = Theme({
+    "primary":   "bold #1E6896",   # lapaz_25 — royal blue, high contrast on both
+    "secondary": "#228B8D",        # lapaz_50 — teal, solid mid-tone
+    "accent":    "#5AADA8",        # lapaz_40ish — slightly lighter teal
+    "success":   "#82C8A0",        # lapaz_75 — sage green, readable on dark/mid BGs
+    "muted":     "#4A7FA5",        # slightly desaturated blue — safe mid-tone
+    "rule":      "#228B8D",        # teal rule lines
+    "warning":   "bold #C4A862",   # warm gold — visible on both (not in lapaz but complements it)
+    "danger":    "bold #C0504A",   # muted red — universal danger signal
+})
+
+console = Console(theme=lapaz_theme)
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -110,7 +123,7 @@ def main(
     fingerprint_dir,
     module_specific_inputs,
     general_inputs,
-):
+    ):
     """Create a new experiment directory with template files using Jinja2 templating."""
 
     # Parse comma-separated sealevel modules into a list
@@ -166,27 +179,24 @@ def main(
                     break
             click.echo(f"  Workflows: {workflow_dict}")
 
-    # Step 1: Create experiment directory and sub-directories
-    click.echo("Step 1: Creating experiment directory and sub-directories...")
-    module_names = [temperature_module] + sealevel_modules_list
+    # Step 2: Create experiment directory and sub-directories
+    console.print("[primary]Step 2:[/primary] Creating experiment directory and sub-directories...")
 
     experiment_path = setup_new_experiment_fs(
         experiment_name=experiment_name, module_names=module_names
     )
 
+    console.print(f"[bold]     Setting up new experiment:[/bold] [secondary]{experiment_name}[/secondary]")
+
+    console.print(f"     ✓ Created experiment directory at: [secondary]{experiment_path}[/secondary]")
+    console.print("[muted]-The experiment has the following modules:[/muted]")
     # Print some setup info
-    exp_setup_message = f"Setting up new experiment: {experiment_name}"
-    click.echo(exp_setup_message)
-    temp_module_message = f"  Temperature module: {temperature_module}"
-    click.echo(temp_module_message)
-    sealevel_modules_message = f"  Sea level modules: {sealevel_modules_list}"
-    click.echo(sealevel_modules_message)
-    framework_modules_message = f"  Framework modules: {framework_modules_list}"
-    click.echo(framework_modules_message)
-    extremesealevel_module_message = (
-        f"  Extreme sea level module: {extremesealevel_module_list}"
-    )
-    click.echo(extremesealevel_module_message)
+    console.print(f"    - Temperature module: [secondary]{temperature_module_list}[/secondary]")
+    console.print(f"    - Sea level modules: [secondary]{sealevel_modules_list}[/secondary]")
+    console.print(f"    - Framework modules: [secondary]{framework_modules_list}[/secondary]")
+    console.print(f"    - Extreme sea level module: [secondary]{extremesealevel_module_list}[/secondary]")
+
+
 
     # Print some CLI info
     if any(
@@ -201,11 +211,11 @@ def main(
             seed,
         ]
     ):
-        click.echo("  CLI arguments provided - will be included in metadata")
-    click.echo("\n" + "=" * 70)
+        console.print("[muted]-CLI arguments provided will be included in metadata[/muted]")
+    console.rule(style="rule")
 
-    # Step 2: Create FactsExperiment from template (FactsExperiment-centric flow)
-    click.echo("Step 2: Generating metadata template...")
+    # Step 2: Create FactsExperiment from template
+    console.print("[primary]Step 3: Generating metadata template...[/primary]")
     experiment = init_new_experiment(
         experiment_name=experiment_name,
         temperature_module=temperature_module,
@@ -230,7 +240,7 @@ def main(
 
     # Step 3: Populate experiment with defaults from defaults.yml files
     # Revert: for module_name in ...: metadata = populate_metadata_with_defaults(metadata, module_name)
-    click.echo("Step 3: Populating metadata with defaults from defaults.yml files...")
+    console.print("[primary]Step 4: Populating metadata with defaults from defaults.yml files...[/primary]")
     for module_name in (
         [temperature_module]
         + sealevel_modules_list
@@ -238,15 +248,14 @@ def main(
         + extremesealevel_module_list
     ):
         if module_name and module_name.upper() != "NONE":
-            modules_message = f"  Populating defaults for module: {module_name}"
-            click.echo(modules_message)
+            console.print(f"  Populating defaults for module: [secondary]{module_name}[/secondary]")
             populate_experiment_defaults(experiment, module_name)
 
-    # Step 5: Write metadata using Jinja2 templating (accepts FactsExperiment or dict)
-    click.echo("Step 4: Writing metadata file using Jinja2 templating...")
+    # Step 4: Write metadata using Jinja2 templating (accepts FactsExperiment or dict)
+    console.print("[primary]Step 5: Writing metadata file using Jinja2 templating...[/primary]")
     metadata_path = experiment_path / "experiment-metadata.yml"
     write_metadata_yaml_jinja2(experiment, metadata_path)
-    click.echo(f"✓ Created experiment-metadata.yml at {metadata_path}")
+    console.print(f"[success]✓ Created experiment-metadata.yml at[/success] [secondary]{metadata_path}[/secondary]")
 
     # Summary
     console.rule(style="rule")

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -14,6 +14,11 @@ from facts_experiment_builder.application.setup_new_experiment import (
 from facts_experiment_builder.infra.write_experiment_metadata import (
     write_metadata_yaml_jinja2,
 )  # TODO move this eventually
+from facts_experiment_builder.core.experiment.module_name_validation import (
+    parse_module_list,
+    validate_module_names,
+)
+from facts_experiment_builder.core.registry import ModuleRegistry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -244,23 +249,74 @@ def main(
     click.echo(f"✓ Created experiment-metadata.yml at {metadata_path}")
 
     # Summary
-    format_message = "\n" + "=" * 70
-    click.echo(format_message)
-    dir_setup_complete_message = "✨ Experiment directory setup complete!"
-    click.echo(dir_setup_complete_message)
-    next_steps_message = "\nNext steps:"
-    click.echo(next_steps_message)
-    edit_metadata_message = f"  1. Edit {metadata_path}"
-    click.echo(edit_metadata_message)
-    fill_in_placeholders_message = (
-        "     - Fill in all placeholder values (pipeline-id, scenario, paths, etc.)"
-    )
-    click.echo(fill_in_placeholders_message)
-    generate_compose_message = "  2. Generate Docker Compose:"
-    click.echo(generate_compose_message)
-    run_compose_message = f"     uv run generate-compose {experiment_path}"
-    click.echo(run_compose_message)
+    console.rule(style="rule")
+    console.print("[success]✨ Experiment directory setup complete![/success]")
+    console.print("\n[primary]Next steps:[/primary]")
+    console.print(f"  [muted]1.[/muted] Edit [secondary]{metadata_path}[/secondary]")
+    console.print("     [muted]Fill in all placeholder values (pipeline-id, scenario, paths, etc.)[/muted]")
+    console.print("  [muted]2.[/muted] Generate Docker Compose:")
+    console.print(f"     [accent]uv run generate-compose {experiment_path}[/accent]")
 
+def _parse_modules_list(
+        temperature_module: str,
+        sealevel_modules: str,
+        framework_module: str,
+        extremesealevel_module: str,
+    ) -> tuple[list[str], list[str], list[str], list[str]]:
+        """Parse the module lists strings and return them as lists"""
+        temperature_module_list = parse_module_list(temperature_module)
+        sealevel_modules_list = parse_module_list(sealevel_modules)
+        framework_modules_list = parse_module_list(framework_module)
+        extremesealevel_module_list = parse_module_list(extremesealevel_module)
+        return (
+            temperature_module_list, 
+            sealevel_modules_list, 
+            framework_modules_list, 
+            extremesealevel_module_list
+        )
+
+def _validate_modules_list(
+        modules_list: list[str],
+    ) -> None:
+
+        valid_module_names = ModuleRegistry.default().list_modules()
+        try:
+            validate_module_names(modules_list, valid_module_names)
+        except ValueError as e:
+            raise click.UsageError(
+                f"{e}\nIt looks like an invalid module name was passed to setup-new-experiment. \nThe modules passed are {modules_list}. \nCheck if you made a typo or if the module is available in the registry (try running 'uv run list-modules')."
+            )
+
+def _collect_workflows() -> dict[str, str]:
+        workflow_dict = {}
+        first = True
+        while True:
+            if first:
+                workflow_name = click.prompt(
+                    "Enter a name for your first workflow, ex. wf1",
+                    type=str,
+                    default="wf1",
+                )
+                first = False
+            else:
+                workflow_name = click.prompt(
+                    "Enter a name for this workflow",
+                    type=str,
+                )
+                workflow_name = workflow_name.strip() or "wf"
+                module_list_str = click.prompt(
+                    "Enter the names of the modules to include in this workflow. "
+                    "Modules should be separated by commas with no spaces between words",
+                    type=str,
+                )
+                workflow_dict[workflow_name] = module_list_str.strip()
+                if not click.confirm(
+                    "Would you like to enter another workflow?",
+                    default=False,
+                ):
+                    break
+            console.print(f"  Workflows: [secondary]{workflow_dict}[/secondary]")
+        return workflow_dict
 
 if __name__ == "__main__":
     main()

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -23,16 +23,18 @@ from facts_experiment_builder.core.registry import ModuleRegistry
 
 # Mid-range lapaz stops — visible on both light and dark terminals
 # Avoids the near-black (#190B35) and near-white (#F9F3C5) extremes
-lapaz_theme = Theme({
-    "primary":   "bold #1E6896",   # lapaz_25 — royal blue, high contrast on both
-    "secondary": "#228B8D",        # lapaz_50 — teal, solid mid-tone
-    "accent":    "#5AADA8",        # lapaz_40ish — slightly lighter teal
-    "success":   "#82C8A0",        # lapaz_75 — sage green, readable on dark/mid BGs
-    "muted":     "#4A7FA5",        # slightly desaturated blue — safe mid-tone
-    "rule":      "#228B8D",        # teal rule lines
-    "warning":   "bold #C4A862",   # warm gold — visible on both (not in lapaz but complements it)
-    "danger":    "bold #C0504A",   # muted red — universal danger signal
-})
+lapaz_theme = Theme(
+    {
+        "primary": "bold #1E6896",  # lapaz_25 — royal blue, high contrast on both
+        "secondary": "#228B8D",  # lapaz_50 — teal, solid mid-tone
+        "accent": "#5AADA8",  # lapaz_40ish — slightly lighter teal
+        "success": "#82C8A0",  # lapaz_75 — sage green, readable on dark/mid BGs
+        "muted": "#4A7FA5",  # slightly desaturated blue — safe mid-tone
+        "rule": "#228B8D",  # teal rule lines
+        "warning": "bold #C4A862",  # warm gold — visible on both (not in lapaz but complements it)
+        "danger": "bold #C0504A",  # muted red — universal danger signal
+    }
+)
 
 console = Console(theme=lapaz_theme)
 
@@ -123,20 +125,32 @@ def main(
     fingerprint_dir,
     module_specific_inputs,
     general_inputs,
-    ):
+):
     """Create a new experiment directory with template files using Jinja2 templating."""
     console.rule(style="rule", title="Setting up new FACTS experiment")
-    console.print("[primary]Step 1:[/primary] I'm reading the information you provided and making sure everything looks okay...")
+    console.print(
+        "[primary]Step 1:[/primary] I'm reading the information you provided and making sure everything looks okay..."
+    )
 
     # Parse comma-separated module names into a list
-    temperature_module_list, sealevel_modules_list, framework_modules_list, extremesealevel_module_list = _parse_modules_list(
+    (
+        temperature_module_list,
+        sealevel_modules_list,
+        framework_modules_list,
+        extremesealevel_module_list,
+    ) = _parse_modules_list(
         temperature_module,
         sealevel_modules,
         framework_module,
         extremesealevel_module,
     )
     # Combine into a total list of all modules in the experiment
-    total_modules_list = temperature_module_list + sealevel_modules_list + framework_modules_list + extremesealevel_module_list
+    total_modules_list = (
+        temperature_module_list
+        + sealevel_modules_list
+        + framework_modules_list
+        + extremesealevel_module_list
+    )
 
     # Validate the total list of modules
     _validate_modules_list(total_modules_list)
@@ -148,23 +162,35 @@ def main(
         workflow_dict = {}
 
     # Step 2: Create experiment directory and sub-directories
-    console.print("[primary]Step 2:[/primary] Creating experiment directory and sub-directories...")
+    console.print(
+        "[primary]Step 2:[/primary] Creating experiment directory and sub-directories..."
+    )
 
     experiment_path = setup_new_experiment_fs(
         experiment_name=experiment_name, module_names=total_modules_list
     )
 
-    console.print(f"[bold]     Setting up new experiment:[/bold] [secondary]{experiment_name}[/secondary]")
+    console.print(
+        f"[bold]     Setting up new experiment:[/bold] [secondary]{experiment_name}[/secondary]"
+    )
 
-    console.print(f"     ✓ Created experiment directory at: [secondary]{experiment_path}[/secondary]")
+    console.print(
+        f"     ✓ Created experiment directory at: [secondary]{experiment_path}[/secondary]"
+    )
     console.print("[muted]-The experiment has the following modules:[/muted]")
     # Print some setup info
-    console.print(f"    - Temperature module: [secondary]{temperature_module_list}[/secondary]")
-    console.print(f"    - Sea level modules: [secondary]{sealevel_modules_list}[/secondary]")
-    console.print(f"    - Framework modules: [secondary]{framework_modules_list}[/secondary]")
-    console.print(f"    - Extreme sea level module: [secondary]{extremesealevel_module_list}[/secondary]")
-
-
+    console.print(
+        f"    - Temperature module: [secondary]{temperature_module_list}[/secondary]"
+    )
+    console.print(
+        f"    - Sea level modules: [secondary]{sealevel_modules_list}[/secondary]"
+    )
+    console.print(
+        f"    - Framework modules: [secondary]{framework_modules_list}[/secondary]"
+    )
+    console.print(
+        f"    - Extreme sea level module: [secondary]{extremesealevel_module_list}[/secondary]"
+    )
 
     # Print some CLI info
     if any(
@@ -179,7 +205,9 @@ def main(
             seed,
         ]
     ):
-        console.print("[muted]-CLI arguments provided will be included in metadata[/muted]")
+        console.print(
+            "[muted]-CLI arguments provided will be included in metadata[/muted]"
+        )
     console.rule(style="rule")
 
     # Step 2: Create FactsExperiment from template
@@ -208,7 +236,9 @@ def main(
 
     # Step 3: Populate experiment with defaults from defaults.yml files
     # Revert: for module_name in ...: metadata = populate_metadata_with_defaults(metadata, module_name)
-    console.print("[primary]Step 4: Populating metadata with defaults from defaults.yml files...[/primary]")
+    console.print(
+        "[primary]Step 4: Populating metadata with defaults from defaults.yml files...[/primary]"
+    )
     for module_name in (
         [temperature_module]
         + sealevel_modules_list
@@ -216,84 +246,95 @@ def main(
         + extremesealevel_module_list
     ):
         if module_name and module_name.upper() != "NONE":
-            console.print(f"  Populating defaults for module: [secondary]{module_name}[/secondary]")
+            console.print(
+                f"  Populating defaults for module: [secondary]{module_name}[/secondary]"
+            )
             populate_experiment_defaults(experiment, module_name)
 
     # Step 4: Write metadata using Jinja2 templating (accepts FactsExperiment or dict)
-    console.print("[primary]Step 5: Writing metadata file using Jinja2 templating...[/primary]")
+    console.print(
+        "[primary]Step 5: Writing metadata file using Jinja2 templating...[/primary]"
+    )
     metadata_path = experiment_path / "experiment-metadata.yml"
     write_metadata_yaml_jinja2(experiment, metadata_path)
-    console.print(f"[success]✓ Created experiment-metadata.yml at[/success] [secondary]{metadata_path}[/secondary]")
+    console.print(
+        f"[success]✓ Created experiment-metadata.yml at[/success] [secondary]{metadata_path}[/secondary]"
+    )
 
     # Summary
     console.rule(style="rule")
     console.print("[success]✨ Experiment directory setup complete![/success]")
     console.print("\n[primary]Next steps:[/primary]")
     console.print(f"  [muted]1.[/muted] Edit [secondary]{metadata_path}[/secondary]")
-    console.print("     [muted]Fill in all placeholder values (pipeline-id, scenario, paths, etc.)[/muted]")
+    console.print(
+        "     [muted]Fill in all placeholder values (pipeline-id, scenario, paths, etc.)[/muted]"
+    )
     console.print("  [muted]2.[/muted] Generate Docker Compose:")
     console.print(f"     [accent]uv run generate-compose {experiment_path}[/accent]")
 
+
 def _parse_modules_list(
-        temperature_module: str,
-        sealevel_modules: str,
-        framework_module: str,
-        extremesealevel_module: str,
-    ) -> tuple[list[str], list[str], list[str], list[str]]:
-        """Parse the module lists strings and return them as lists"""
-        temperature_module_list = parse_module_list(temperature_module)
-        sealevel_modules_list = parse_module_list(sealevel_modules)
-        framework_modules_list = parse_module_list(framework_module)
-        extremesealevel_module_list = parse_module_list(extremesealevel_module)
-        return (
-            temperature_module_list, 
-            sealevel_modules_list, 
-            framework_modules_list, 
-            extremesealevel_module_list
-        )
+    temperature_module: str,
+    sealevel_modules: str,
+    framework_module: str,
+    extremesealevel_module: str,
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Parse the module lists strings and return them as lists"""
+    temperature_module_list = parse_module_list(temperature_module)
+    sealevel_modules_list = parse_module_list(sealevel_modules)
+    framework_modules_list = parse_module_list(framework_module)
+    extremesealevel_module_list = parse_module_list(extremesealevel_module)
+    return (
+        temperature_module_list,
+        sealevel_modules_list,
+        framework_modules_list,
+        extremesealevel_module_list,
+    )
+
 
 def _validate_modules_list(
-        modules_list: list[str],
-    ) -> None:
+    modules_list: list[str],
+) -> None:
+    valid_module_names = ModuleRegistry.default().list_modules()
+    try:
+        validate_module_names(modules_list, valid_module_names)
+    except ValueError as e:
+        raise click.UsageError(
+            f"{e}\nIt looks like an invalid module name was passed to setup-new-experiment. \nThe modules passed are {modules_list}. \nCheck if you made a typo or if the module is available in the registry (try running 'uv run list-modules')."
+        )
 
-        valid_module_names = ModuleRegistry.default().list_modules()
-        try:
-            validate_module_names(modules_list, valid_module_names)
-        except ValueError as e:
-            raise click.UsageError(
-                f"{e}\nIt looks like an invalid module name was passed to setup-new-experiment. \nThe modules passed are {modules_list}. \nCheck if you made a typo or if the module is available in the registry (try running 'uv run list-modules')."
-            )
 
 def _collect_workflows() -> dict[str, str]:
-        workflow_dict = {}
-        first = True
-        while True:
-            if first:
-                workflow_name = click.prompt(
-                    "Enter a name for your first workflow, ex. wf1",
-                    type=str,
-                    default="wf1",
-                )
-                first = False
-            else:
-                workflow_name = click.prompt(
-                    "Enter a name for this workflow",
-                    type=str,
-                )
-                workflow_name = workflow_name.strip() or "wf"
-                module_list_str = click.prompt(
-                    "Enter the names of the modules to include in this workflow. "
-                    "Modules should be separated by commas with no spaces between words",
-                    type=str,
-                )
-                workflow_dict[workflow_name] = module_list_str.strip()
-                if not click.confirm(
-                    "Would you like to enter another workflow?",
-                    default=False,
-                ):
-                    break
-            console.print(f"  Workflows: [secondary]{workflow_dict}[/secondary]")
-        return workflow_dict
+    workflow_dict = {}
+    first = True
+    while True:
+        if first:
+            workflow_name = click.prompt(
+                "Enter a name for your first workflow, ex. wf1",
+                type=str,
+                default="wf1",
+            )
+            first = False
+        else:
+            workflow_name = click.prompt(
+                "Enter a name for this workflow",
+                type=str,
+            )
+            workflow_name = workflow_name.strip() or "wf"
+            module_list_str = click.prompt(
+                "Enter the names of the modules to include in this workflow. "
+                "Modules should be separated by commas with no spaces between words",
+                type=str,
+            )
+            workflow_dict[workflow_name] = module_list_str.strip()
+            if not click.confirm(
+                "Would you like to enter another workflow?",
+                default=False,
+            ):
+                break
+        console.print(f"  Workflows: [secondary]{workflow_dict}[/secondary]")
+    return workflow_dict
+
 
 if __name__ == "__main__":
     main()

--- a/src/facts_experiment_builder/core/experiment/module_name_validation.py
+++ b/src/facts_experiment_builder/core/experiment/module_name_validation.py
@@ -1,0 +1,15 @@
+def parse_module_list(s: str | None) -> list[str]:
+    """Parse a comma-separated string of module names into a list of stripped names"""
+
+    if not s:
+        return []
+    return [m.strip() for m in s.split(",") if m.strip()]
+
+
+def validate_module_names(module_names: list[str], valid_modules: set[str]) -> None:
+    """Raise ValueError if any module name is not in the valid set"""
+    invalid_names = [name for name in module_names if name not in valid_modules]
+    if invalid_names:
+        raise ValueError(
+            f"Invalid module name(s): {', '.join(invalid_names)}."
+            )

--- a/src/facts_experiment_builder/core/experiment/module_name_validation.py
+++ b/src/facts_experiment_builder/core/experiment/module_name_validation.py
@@ -10,6 +10,4 @@ def validate_module_names(module_names: list[str], valid_modules: set[str]) -> N
     """Raise ValueError if any module name is not in the valid set"""
     invalid_names = [name for name in module_names if name not in valid_modules]
     if invalid_names:
-        raise ValueError(
-            f"Invalid module name(s): {', '.join(invalid_names)}."
-            )
+        raise ValueError(f"Invalid module name(s): {', '.join(invalid_names)}.")

--- a/src/facts_experiment_builder/infra/experiment_manager.py
+++ b/src/facts_experiment_builder/infra/experiment_manager.py
@@ -34,4 +34,3 @@ def create_experiment_directory_files(
     if module_names:
         for name in module_names:
             (data_dir / name).mkdir(parents=True)
-    print("✓ Created data/output directory")

--- a/src/facts_experiment_builder/infra/path_utils.py
+++ b/src/facts_experiment_builder/infra/path_utils.py
@@ -11,7 +11,10 @@ _KNOWN_MODULE_NAMES: Optional[frozenset] = None
 def _registry_module_names() -> frozenset:
     global _KNOWN_MODULE_NAMES
     if _KNOWN_MODULE_NAMES is None:
-        from facts_experiment_builder.core.registry.module_registry import ModuleRegistry
+        from facts_experiment_builder.core.registry.module_registry import (
+            ModuleRegistry,
+        )
+
         _KNOWN_MODULE_NAMES = frozenset(ModuleRegistry.default().list_modules())
     return _KNOWN_MODULE_NAMES
 
@@ -138,6 +141,7 @@ def build_module_output_paths(
             f"output_dir has invalid type for {module_name}: expected str, got {type(output_dir)}"
         )
     return ModuleOutputPaths(output_dir=output_dir, output_type=output_type)
+
 
 def is_general_input(field_name: str) -> bool:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "netcdf4" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "xarray" },
 ]
 
@@ -123,6 +124,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "netcdf4", specifier = ">=1.7.3" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "rich", specifier = ">=14.3.3" },
     { name = "xarray", specifier = ">=2025.12.0" },
 ]
 
@@ -169,6 +171,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -232,6 +246,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -483,6 +506,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->

### Add `list-modules` command
- there is now a list modules cli command that prints the modules that are found in the module registry and are available to use in experiments

### cli formatting
- Adds a color theme based on la paz from [scientific colourmaps](https://www.fabiocrameri.ch/colourmaps/) (happy to change depending on what others think, this was mostly just for fun)
- Uses rich text formatting and cleans up the text that is printed during execution of setup new experiment

### refactor setup new experiment cli
- this adds some new functions to make the script more testable
- also uses module registry to check for valid modules

### module name validation
- adds module to core.experiment to parse modules from a string and validate that modules exist in registry 

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [X] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [X] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [X] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...
Yes, claude code cli used in parts. all code reviewed directly by me


## Checklist
- [x] Code runs without errors locally
- [ ] Tests added or updated (if applicable)
- [ ] Existing tests pass
- [x] Data inputs/outputs are documented or unchanged
- [x] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)