### PR TITLE
Update climate and sealevel data arg names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ cd fresh_facts_project
 #### 2. Create an experiment via CLI
 - at a minimum, this entails specifying:
      - `--experiment-name`
-     - `--climate-step` OR `--climate-step-data` (module name or path to pre-existing climate data)
-     - `--sealevel-step` OR `--supplied-totaled-sealevel-data` (module name(s) or path to pre-existing sealevel data)
-     - `--totaling-step` defaults to `facts-total`; pass `NONE` to skip (automatically skipped when `--sealevel-step-data` is used)
+     - `--climate-step` OR `--supplied-climate-step-data` (module name or path to pre-existing climate data)
+     - `--sealevel-step` OR `--supplied-totaled-sealevel-step-data` (module name(s) or path to pre-existing sealevel data)
+     - `--totaling-step` defaults to `facts-total`; pass `NONE` to skip (automatically skipped when `--supplied-totaled-sealevel-step-data` is used)
      - `--extremesealevel-step` (ie. `extremesealevel-pointsoverthreshold`)
      - For full features list, see help section below.
 
@@ -60,7 +60,7 @@ Example (using pre-existing climate data instead of running a climate module):
 uvx --from git+https://github.com/fact-sealevel/facts-experiment-builder@main setup-new-experiment \
 --experiment-name toy_experiment_with_climate_data --scenario ssp585 \
 --pyear-start 2020 --pyear-end 2100 --pyear-step 10 --baseyear 2005 --seed 1234 --nsamps 1000 \
---climate-step-data /path/to/climate_data.nc \
+--supplied-climate-step-data /path/to/climate_data.nc \
 --sealevel-step bamber19-icesheets,tlm-sterodynamics \
 --totaling-step facts-total \
 --extremesealevel-step extremesealevel-pointsoverthreshold
@@ -110,8 +110,8 @@ This is a command line application with two main functions:
 Initialize a new experiment by calling this command and providing an experiment name and the modules (or pre-existing data) for each step. `facts-experiment-builder` creates a sub-directory to hold run files and outputs associated with this experiment. It also generates and prepopulates an `experiment-metadata.yml` based on the arguments provided by the user. The user must then enter any remaining fields in `experiment-metadata.yml` before it is considered complete.
 
 Each step accepts either a module name or a path to pre-existing data:
-- `--climate-step` / `--climate-step-data`: run a climate module or provide climate output directly
-- `--sealevel-step` / `--supplied-totaled-sealevel-data`: run sealevel module(s) or provide sealevel output directly (totaling is automatically skipped when `--sealevel-step-data` is used)
+- `--climate-step` / `--supplied-climate-step-data`: run a climate module or provide climate output directly
+- `--sealevel-step` / `--supplied-totaled-sealevel-step-data`: run sealevel module(s) or provide sealevel output directly (totaling is automatically skipped when `--supplied-totaled-sealevel-step-data` is used)
 
 ```shell
 uv run setup-new-experiment --help
@@ -122,11 +122,11 @@ Usage: setup-new-experiment [OPTIONS]
 Options:
   --experiment-name TEXT         Name of the experiment  [required]
   --climate-step TEXT            Name of the temperature module
-  --climate-step-data PATH       Path to data to use in place of running a
+  --supplied-climate-step-data PATH       Path to data to use in place of running a
                                  module in the climate step of the experiment.
   --sealevel-step TEXT           Names of the sea level modules, separated by
                                  commas
-  --sealevel-step-data PATH      Path to data to use in place of running
+  --supplied-totaled-sealevel-step-data PATH      Path to data to use in place of running
                                  modules in sea-level step
   --totaling-step TEXT           Name of the totaling step module (use 'NONE'
                                  if you do not want to call the totaling

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -336,7 +336,7 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
         and not modules["esl_modules"]
     ):
         has_step_data = bool(
-            metadata.get("sealevel-step-data")
+            metadata.get("supplied-totaled-sealevel-step-data")
             or metadata.get("experiment-specific-input-data")
         )
         if has_step_data:

--- a/src/facts_experiment_builder/application/setup_new_experiment.py
+++ b/src/facts_experiment_builder/application/setup_new_experiment.py
@@ -84,7 +84,7 @@ def hydrate_sealevel_step(skeleton) -> SealevelStep:
                     )
     else:
         sealevel_step = SealevelStep(
-            supplied_totaled_sealevel_data=skeleton.supplied_totaled_sealevel_data
+            supplied_totaled_sealevel_data=skeleton.supplied_totaled_sealevel_step_data
         )
     return sealevel_step
 
@@ -98,7 +98,7 @@ def hydrate_experiment(skeleton: ExperimentSkeleton) -> tuple:
         climate_step = ClimateStep.from_module_schema(
             load_facts_module_by_name(skeleton.climate_module)
         )
-    elif skeleton.supplied_totaled_sealevel_data:
+    elif skeleton.supplied_totaled_sealevel_step_data:
         climate_step = ClimateStep.not_needed()
     else:
         climate_step = ClimateStep(alternate_climate_data=skeleton.climate_data)
@@ -210,12 +210,12 @@ def experiment_skeleton_to_facts_experiment(
         ),
         **(
             {
-                "supplied-totaled-sealevel-data": create_metadata_bundle(
+                "supplied-totaled-sealevel-step-data": create_metadata_bundle(
                     "Path to pre-existing totaled sealevel data (replaces running climate and sealevel modules)",
-                    skeleton.supplied_totaled_sealevel_data,
+                    skeleton.supplied_totaled_sealevel_step_data,
                 )
             }
-            if skeleton.supplied_totaled_sealevel_data
+            if skeleton.supplied_totaled_sealevel_step_data
             else {}
         ),
     }

--- a/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_new_experiment_cli.py
@@ -38,7 +38,7 @@ from facts_experiment_builder.core.registry import ModuleRegistry
     "--climate-step", type=str, required=False, help="Name of the temperature module"
 )
 @click.option(
-    "--climate-step-data",
+    "--supplied-climate-step-data",
     type=click.Path(exists=True),
     required=False,
     help="Path to data to use in place of running a module in the climate step of the experiment.",
@@ -50,7 +50,7 @@ from facts_experiment_builder.core.registry import ModuleRegistry
     help="Names of the sea level modules, separated by commas",
 )
 @click.option(
-    "--supplied-totaled-sealevel-data",
+    "--supplied-totaled-sealevel-step-data",
     type=click.Path(exists=True),
     required=False,
     help="Path to pre-existing totaled sealevel data. Replaces running both the climate and sealevel steps.",
@@ -110,9 +110,9 @@ from facts_experiment_builder.core.registry import ModuleRegistry
 def main(
     experiment_name,
     climate_step,
-    climate_step_data,
+    supplied_climate_step_data,
     sealevel_step,
-    supplied_totaled_sealevel_data,
+    supplied_totaled_sealevel_step_data,
     totaling_step,
     extremesealevel_step,
     pipeline_id,
@@ -145,29 +145,29 @@ def main(
     _check_for_required_args(
         experiment_name=experiment_name,
         climate_step=climate_step,
-        climate_step_data=climate_step_data,
+        supplied_climate_step_data=supplied_climate_step_data,
         sealevel_step=sealevel_step,
-        supplied_totaled_sealevel_data=supplied_totaled_sealevel_data,
+        supplied_totaled_sealevel_step_data=supplied_totaled_sealevel_step_data,
     )
 
     # Build the skeleton from CLI inputs (parses comma-separated strings, no YAML loading)
     skeleton = ExperimentSkeleton.from_cli_inputs(
         climate_step=climate_step,
-        climate_step_data=climate_step_data,
+        supplied_climate_step_data=supplied_climate_step_data,
         sealevel_step=sealevel_step,
-        sealevel_step_data=supplied_totaled_sealevel_data,
+        supplied_totaled_sealevel_step_data=supplied_totaled_sealevel_step_data,
         totaling_step=totaling_step,
         extremesealevel_step=extremesealevel_step,
     )
 
     # If totaled sealevel data is provided, totaling cannot run (no sealevel outputs to total)
     if (
-        skeleton.supplied_totaled_sealevel_data
+        skeleton.supplied_totaled_sealevel_step_data
         and skeleton.totaling_module
         and skeleton.totaling_module.upper() != "NONE"
     ):
         console.print(
-            "[muted]Note: Totaling step is being skipped because --supplied-totaled-sealevel-data was provided.[/muted]"
+            "[muted]Note: Totaling step is being skipped because --supplied-totaled-sealevel-step-data was provided.[/muted]"
         )
         skeleton = dataclasses.replace(skeleton, totaling_module=None)
 
@@ -227,7 +227,7 @@ def main(
         location_file=location_file,
         fingerprint_dir=fingerprint_dir,
         module_specific_inputs=module_specific_inputs,
-        experiment_specific_inputs=climate_step_data,
+        experiment_specific_inputs=supplied_climate_step_data,
         general_inputs=general_inputs,
     )
 
@@ -280,25 +280,28 @@ def _check_experiment_step(step_module, step_data, step_module_name, step_data_n
 def _check_for_required_args(
     experiment_name,
     climate_step,
-    climate_step_data,
+    supplied_climate_step_data,
     sealevel_step,
-    supplied_totaled_sealevel_data,
+    supplied_totaled_sealevel_step_data,
 ):
     if not experiment_name:
         raise click.UsageError(
             "Missing required argument 'experiment_name'. You must pass one with --experiment-name"
         )
     # Climate step is optional when totaled sealevel data is provided (no climate step needed)
-    if not supplied_totaled_sealevel_data:
+    if not supplied_totaled_sealevel_step_data:
         _check_experiment_step(
-            climate_step, climate_step_data, "--climate-step", "--climate-step-data"
+            climate_step,
+            supplied_climate_step_data,
+            "--climate-step",
+            "--supplied-climate-step-data",
         )
     # Check sealevel step: either modules, or totaled sealevel data
     _check_experiment_step(
         sealevel_step,
-        supplied_totaled_sealevel_data,
+        supplied_totaled_sealevel_step_data,
         "--sealevel-step",
-        "--supplied-totaled-sealevel-data",
+        "--supplied-totaled-sealevel-step-data",
     )
 
 
@@ -377,7 +380,7 @@ def print_climate_step_info(skeleton: "ExperimentSkeleton"):
 
 
 def print_sealevel_step_info(skeleton: "ExperimentSkeleton"):
-    value = skeleton.sealevel_modules or skeleton.supplied_totaled_sealevel_data
+    value = skeleton.sealevel_modules or skeleton.supplied_totaled_sealevel_step_data
     console.print(f"    - Sea level step: [secondary]{value}[/secondary]")
 
 

--- a/src/facts_experiment_builder/core/experiment/experiment_skeleton.py
+++ b/src/facts_experiment_builder/core/experiment/experiment_skeleton.py
@@ -16,7 +16,7 @@ class ExperimentSkeleton:
     climate_module: Optional[str]  # None if data provided
     climate_data: Optional[str]  # None if module provided
     sealevel_modules: List[str]  # [] if data provided
-    supplied_totaled_sealevel_data: Optional[str]  # None if modules provided
+    supplied_totaled_sealevel_step_data: Optional[str]  # None if modules provided
     totaling_module: Optional[str]  # None if no totaling step
     extremesealevel_module: Optional[str]  # None if no ESL step
     workflows: Dict[str, str] = field(default_factory=dict)
@@ -25,9 +25,9 @@ class ExperimentSkeleton:
     def from_cli_inputs(
         cls,
         climate_step: Optional[str],
-        climate_step_data: Optional[str],
+        supplied_climate_step_data: Optional[str],
         sealevel_step: Optional[str],
-        sealevel_step_data: Optional[str],
+        supplied_totaled_sealevel_step_data: Optional[str],
         totaling_step: Optional[str],
         extremesealevel_step: Optional[str],
     ) -> "ExperimentSkeleton":
@@ -43,9 +43,9 @@ class ExperimentSkeleton:
 
         return cls(
             climate_module=climate_modules[0] if climate_modules else None,
-            climate_data=climate_step_data,
+            climate_data=supplied_climate_step_data,
             sealevel_modules=sealevel_modules,
-            supplied_totaled_sealevel_data=sealevel_step_data,
+            supplied_totaled_sealevel_step_data=supplied_totaled_sealevel_step_data,
             totaling_module=totaling_modules[0] if totaling_modules else None,
             extremesealevel_module=esl_modules[0] if esl_modules else None,
         )

--- a/src/facts_experiment_builder/core/typed_path.py
+++ b/src/facts_experiment_builder/core/typed_path.py
@@ -15,7 +15,7 @@ class TypedPath:
       determined by the module YAML mount spec.
     - "container": already a container path; used as-is.
     - "experiment_specific_in": host path for user-supplied experiment data (e.g.
-      climate data passed via --climate-step-data); always routed to
+      climate data passed via --supplied-climate-step-data); always routed to
       /mnt/experiment_specific_in/<filename> with the parent directory volume-mounted.
     """
 

--- a/src/facts_experiment_builder/infra/write_experiment_metadata.py
+++ b/src/facts_experiment_builder/infra/write_experiment_metadata.py
@@ -313,8 +313,8 @@ def write_metadata_yaml_jinja2(experiment: FactsExperiment, output_path: Path):
         inputs.append("general-input-data")
     if "experiment-specific-input-data" in experiment.paths:
         inputs.append("experiment-specific-input-data")
-    if "supplied-totaled-sealevel-data" in experiment.paths:
-        inputs.append("supplied-totaled-sealevel-data")
+    if "supplied-totaled-sealevel-step-data" in experiment.paths:
+        inputs.append("supplied-totaled-sealevel-step-data")
 
     # Outputs section (output-data-location)
     outputs = []

--- a/tests/unit/test_setup_new_experiment.py
+++ b/tests/unit/test_setup_new_experiment.py
@@ -24,7 +24,7 @@ def make_skeleton(
     climate_module=None,
     climate_data=None,
     sealevel_modules=None,
-    supplied_totaled_sealevel_data=None,
+    supplied_totaled_sealevel_step_data=None,
     totaling_module=None,
     extremesealevel_module=None,
 ) -> ExperimentSkeleton:
@@ -32,7 +32,7 @@ def make_skeleton(
         climate_module=climate_module,
         climate_data=climate_data,
         sealevel_modules=sealevel_modules or [],
-        supplied_totaled_sealevel_data=supplied_totaled_sealevel_data,
+        supplied_totaled_sealevel_step_data=supplied_totaled_sealevel_step_data,
         totaling_module=totaling_module,
         extremesealevel_module=extremesealevel_module,
     )
@@ -96,8 +96,8 @@ def test_hydrate_experiment_esl_module_produces_module_spec(mock_load):
 # --- hydrate_sealevel_step ---
 
 
-def test_hydrate_sealevel_step_no_modules_uses_supplied_totaled_sealevel_data():
-    skeleton = make_skeleton(supplied_totaled_sealevel_data="/path/to/sealevel")
+def test_hydrate_sealevel_step_no_modules_uses_supplied_totaled_sealevel_step_data():
+    skeleton = make_skeleton(supplied_totaled_sealevel_step_data="/path/to/sealevel")
 
     step = hydrate_sealevel_step(skeleton)
 


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->
This PR changes `climate-step-data` to `supplied-climate-step-data` and the sealevel version to `supplied-sealevel-step-data` for consistency

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [x] Refactor / cleanup
- [x] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [x] Yes — describe below
- [ ] No

> _Breaking change details (if applicable):_
This changes the name of two sealevel args, passing data instead of running the modules for the climate or sealevel steps. they are now `--supplied-climate-step-data` and `--supplied-sealevel-step-data`


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...
Claude, reviewed by me


## Checklist
- [x] Code runs without errors locally
- [x] Tests added or updated (if applicable)
- [x] Existing tests pass
- [ ] Data inputs/outputs are documented or unchanged
- [ ] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)