### PR TITLE
Consolidate and condense CLI to `feb setup` and `feb generate`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 [project.scripts]
+feb = "facts_experiment_builder.cli:main"
 facts-experiment-builder = "facts_experiment_builder.cli.cli:main"
 setup-new-experiment = "facts_experiment_builder.cli.setup_new_experiment_cli:main"
 setup-new-experiment-jinja2 = "facts_experiment_builder.cli.setup_new_experiment_jinja2_cli:main"

--- a/src/facts_experiment_builder/cli/__init__.py
+++ b/src/facts_experiment_builder/cli/__init__.py
@@ -12,5 +12,5 @@ def main():
     pass
 
 
-main.add_command(setup_new_experiment_group, name="setup-new-experiment")
-main.add_command(generate_compose_group, name="generate-compose")
+main.add_command(setup_new_experiment_group, name="setup")
+main.add_command(generate_compose_group, name="generate")

--- a/src/facts_experiment_builder/cli/__init__.py
+++ b/src/facts_experiment_builder/cli/__init__.py
@@ -1,12 +1,12 @@
+import click
+
 from facts_experiment_builder.cli.setup_new_experiment_cli import (
     main as setup_new_experiment_group,
 )
 from facts_experiment_builder.cli.generate_compose_cli import (
     main as generate_compose_group,
 )
-from facts_experiment_builder.cli.list_modules_cli import (
-     main as list_modules_group
-import click
+from facts_experiment_builder.cli.list_modules_cli import list_modules as list_modules
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -16,4 +16,4 @@ def main():
 
 main.add_command(setup_new_experiment_group, name="setup-experiment")
 main.add_command(generate_compose_group, name="generate-compose")
-main.add_command(list_modules_group, name="list-modules")
+main.add_command(list_modules, name="list-modules")

--- a/src/facts_experiment_builder/cli/__init__.py
+++ b/src/facts_experiment_builder/cli/__init__.py
@@ -4,6 +4,8 @@ from facts_experiment_builder.cli.setup_new_experiment_cli import (
 from facts_experiment_builder.cli.generate_compose_cli import (
     main as generate_compose_group,
 )
+from facts_experiment_builder.cli.list_modules_cli import (
+     main as list_modules_group
 import click
 
 
@@ -12,5 +14,6 @@ def main():
     pass
 
 
-main.add_command(setup_new_experiment_group, name="setup")
-main.add_command(generate_compose_group, name="generate")
+main.add_command(setup_new_experiment_group, name="setup-experiment")
+main.add_command(generate_compose_group, name="generate-compose")
+main.add_command(list_modules_group, name="list-modules")


### PR DESCRIPTION
## Description
Demonstrates one way to consolidate and condense the CLI. When the package is installed, people can run the main steps with the `feb setup` and `feb generate` commands from their terminal.

If someone installed it via `uv tools` or an active pip environment the tool runs like
```
feb --help
feb setup --help
feb generate --help
```
With `uvx`, running directly from the repo this is something like
```
uvx --with="git+https://github.com/fact-sealevel/facts-experiment-builder" feb setup --help
```


If this is to become the main path for running the CLI then documentation will need to be updated. This means docs in cli/ including the help docstrs in cli/ and README.md. 

There might also be some cruft. It might help to remove other project.scripts entries from pyrproject.toml, if they're unused and unused code and entry points from cli/ modules. These changes are beyond what I can do in this PR but feel free to modify this PR/branch directly with the changes if you don't address things in another PR.


## Type of Change
- [ ] Bug fix
- [x] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [ ] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [x] Yes — describe below
- [ ] No

Unlikely but possibly breaking change. If anyone ran the CLI commands through facts_experiement_builder.cli:main then that no longer works as before. Seems like that was abandoned or unused cruft.

## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI

No gen AI was used.


## Checklist
- [x] Code runs without errors locally
- [x] Tests added or updated (if applicable)
- [x] Existing tests pass
- [x] Data inputs/outputs are documented or unchanged
- [x] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [x] Results are reproducible (seed set, environment pinned, etc.)