### PR TITLE
fix service creation

### DIFF
--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -124,7 +124,7 @@ def _validate_climate_file_inputs(
             f"input key) in the inputs section for each sealevel module."
         )
 
-    
+
 def _collect_workflow_output_paths_by_type(
     metadata: Dict[str, Any],
     wf: Workflow,
@@ -152,36 +152,54 @@ def _collect_workflow_output_paths_by_type(
             if isinstance(v, dict) and "value" in v:
                 p = v.get("value") or ""
                 ot = v.get("output_type", "")
-            #elif isinstance(v, str):
+            # elif isinstance(v, str):
             #    p = v
             #    ot = "local"
 
             else:
                 continue
             if p and isinstance(p, str) and ot == output_type:
-                if "wais" in p:   #TODO this is a hacky fix, should prob be handled in module registry entry
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                if (
+                    "wais" in p
+                ):  # TODO this is a hacky fix, should prob be handled in module registry entry
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "eais" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "pen" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "smb" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "SMB" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "WAIS" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "EAIS" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 elif "PEN" in p:
-                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    print(
+                        f"{p}: This output is component of a larger unit and is already represented elsewhere; skipping."
+                    )
                     continue
                 paths.append(f"{prefix}/{p.strip()}")
     return paths

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -124,7 +124,7 @@ def _validate_climate_file_inputs(
             f"input key) in the inputs section for each sealevel module."
         )
 
-
+    
 def _collect_workflow_output_paths_by_type(
     metadata: Dict[str, Any],
     wf: Workflow,
@@ -152,12 +152,37 @@ def _collect_workflow_output_paths_by_type(
             if isinstance(v, dict) and "value" in v:
                 p = v.get("value") or ""
                 ot = v.get("output_type", "")
-            elif isinstance(v, str):
-                p = v
-                ot = "local"
+            #elif isinstance(v, str):
+            #    p = v
+            #    ot = "local"
+
             else:
                 continue
             if p and isinstance(p, str) and ot == output_type:
+                if "wais" in p:   #TODO this is a hacky fix, should prob be handled in module registry entry
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "eais" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "pen" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "smb" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "SMB" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "WAIS" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "EAIS" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
+                elif "PEN" in p:
+                    print(f'{p}: This output is component of a larger unit and is already represented elsewhere; skipping.')
+                    continue
                 paths.append(f"{prefix}/{p.strip()}")
     return paths
 


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->
In an earlier change, logic handling which outputs from a sealevel module should be passed to facts total were lost. this adds them back in in the `generate_compose.py` script of the application layer when a `facts-total` service is created. not a long-term solution but should work for now. ultimately this should probably be handled at the module-level, either in a module's entry in the module registry entry or `core/module`. 

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [x] Bug fix
- [ ] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [ ] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [ ] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...
No.


## Checklist
- [ ] Code runs without errors locally
- [ ] Tests added or updated (if applicable)
- [x] Existing tests pass
- [ ] Data inputs/outputs are documented or unchanged
- [ ] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)