### PR TITLE
Fix module registry error calls, refactor `generate_compose()`, add `HostDirPath`, rework generate compose cli msgs

### DIFF
--- a/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
+++ b/src/facts_experiment_builder/adapters/experiment_metadata_to_service_spec.py
@@ -22,11 +22,12 @@ from facts_experiment_builder.core.module.module_service_spec import (
 from facts_experiment_builder.core.module.module_schema import ModuleContainerImage
 from facts_experiment_builder.core.typed_path import (
     HostPath,
+    HostDirPath,
     ContainerPath,
     ExperimentSpecificInputPath,
 )
 from facts_experiment_builder.infra.module_loader import (
-    load_facts_module_from_yaml,
+    load_module_schema_from_yaml,
     find_module_yaml_path,
 )
 
@@ -50,6 +51,18 @@ def _registry_module_names() -> frozenset:
 
         _KNOWN_MODULE_NAMES = frozenset(ModuleRegistry.default().list_modules())
     return _KNOWN_MODULE_NAMES
+
+
+def _dir_input_keys(module_definition: Any) -> Set[str]:
+    """Return set of input field names declared as directory paths (type: 'dir') in the module YAML."""
+    keys: Set[str] = set()
+    for arg_spec in module_definition.arguments.get("inputs", []):
+        if arg_spec.get("type") != "dir":
+            continue
+        source = arg_spec.get("source", "")
+        if "." in source:
+            keys.add(source.split(".")[-1])
+    return keys
 
 
 def _multiple_file_input_keys(module_definition: Any) -> Set[str]:
@@ -102,7 +115,7 @@ def build_module_service_spec(
     else:
         # this is climate + sea level module steps
         resolved_yaml_path = find_module_yaml_path(module_name)
-    module_definition = load_facts_module_from_yaml(resolved_yaml_path)
+    module_definition = load_module_schema_from_yaml(resolved_yaml_path)
     module_metadata = get_required_field(metadata, module_name, module_context)
 
     scenario_name = get_required_field(metadata, "scenario", module_context)
@@ -190,6 +203,7 @@ def build_module_service_spec(
     output_root_relative_inputs = module_definition.get_output_volume_input_keys()
 
     multiple_file_input_keys = _multiple_file_input_keys(module_definition)
+    dir_input_keys = _dir_input_keys(module_definition)
 
     inputs_dict = {}
     for key, value in module_inputs_section.items():
@@ -278,7 +292,11 @@ def build_module_service_spec(
                     module_name,
                     module_context,
                 )
-                inputs_dict[key] = HostPath(resolved_path)
+                inputs_dict[key] = (
+                    HostDirPath(resolved_path)
+                    if key in dir_input_keys
+                    else HostPath(resolved_path)
+                )
             except (ValueError, KeyError, TypeError) as e:
                 error_msg = str(e)
                 if "None" in error_msg or "NoneType" in error_msg:

--- a/src/facts_experiment_builder/adapters/module_adapter.py
+++ b/src/facts_experiment_builder/adapters/module_adapter.py
@@ -11,7 +11,7 @@ from facts_experiment_builder.infra.experiment_loader import load_experiment_met
 
 
 def create_module_service_spec_from_metadata(
-    metadata_path: Path,
+    experiment_dir: Path,
     module_name: str,
     module_type: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
@@ -21,18 +21,18 @@ def create_module_service_spec_from_metadata(
     Create a single module service spec from experiment metadata.
 
     Args:
-        metadata_path: Path to experiment-config.yaml
+        experiment_dir: Path to dir containing experiment-config.yaml
         module_name: Module name (e.g. 'fair-temperature', 'bamber19-icesheets')
         module_type: Optional category (e.g. 'temperature_module', 'sealevel_module')
-        metadata: Optional pre-loaded metadata (if provided, metadata_path is used only for experiment_dir)
+        metadata: Optional pre-loaded metadata. If provided, skips loading from disk.
         module_yaml_path: Optional path to module YAML (e.g. for facts-total workflow services)
 
     Returns:
         ModuleServiceSpec
     """
+    metadata_path = Path(experiment_dir, "experiment-config.yaml")
     if metadata is None:
         metadata = load_experiment_metadata(metadata_path)
-    experiment_dir = metadata_path.parent
 
     try:
         return build_module_service_spec(

--- a/src/facts_experiment_builder/application/check_data.py
+++ b/src/facts_experiment_builder/application/check_data.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import List
 
 from facts_experiment_builder.core.registry.module_registry import ModuleRegistry
-from facts_experiment_builder.infra.module_loader import load_facts_module_from_yaml
+from facts_experiment_builder.infra.module_loader import load_module_schema_from_yaml
 from facts_experiment_builder.infra.path_utils import is_shared_input
 
 
@@ -79,7 +79,7 @@ def _check_module(
 
     try:
         yaml_path = registry.get_module_yaml_path(module_name)
-        schema = load_facts_module_from_yaml(yaml_path)
+        schema = load_module_schema_from_yaml(yaml_path)
     except FileNotFoundError:
         return result
 
@@ -191,7 +191,7 @@ def check_shared_data(
     for module_name in discovered_module_names:
         try:
             yaml_path = registry.get_module_yaml_path(module_name)
-            schema = load_facts_module_from_yaml(yaml_path)
+            schema = load_module_schema_from_yaml(yaml_path)
         except FileNotFoundError:
             continue
 

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -12,14 +12,17 @@ Usage:
 """
 
 import yaml
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional, Set
 
 from facts_experiment_builder.adapters.module_adapter import (
     create_module_service_spec_from_metadata,
 )
 from facts_experiment_builder.adapters.adapter_utils import get_experiment_paths
 from facts_experiment_builder.core.experiment import FactsExperiment
+from facts_experiment_builder.core.module.module_service_spec import ModuleServiceSpec
+from facts_experiment_builder.core.registry import ModuleRegistry
 from facts_experiment_builder.core.workflow.workflow import (
     Workflow,
     workflows_from_metadata,
@@ -28,8 +31,8 @@ from facts_experiment_builder.infra.path_manager import find_module_yaml_path
 from facts_experiment_builder.infra.path_utils import expand_path
 from facts_experiment_builder.infra.experiment_loader import load_experiment_metadata
 from facts_experiment_builder.infra.module_loader import (
-    load_facts_module_from_yaml,
-    load_facts_module_by_name,
+    load_module_schema_by_name,
+    load_module_schema_from_yaml,
 )
 from facts_experiment_builder.core.module.module_schema import (
     collect_metadata_param_keys,
@@ -38,6 +41,49 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+_SUCCESS = 25  # custom level between INFO (20) and WARNING (30); must match CLI handler
+
+_REQUIRED_FIELDS = [
+    "experiment_name",
+    "pipeline-id",
+    "nsamps",
+    "scenario",
+    "pyear_start",
+    "pyear_end",
+    "pyear_step",
+    "baseyear",
+    "module-specific-input-data",
+    "shared-input-data",
+    "output-data-location",
+]
+
+
+@dataclass(frozen=True)
+class _ExperimentPlan:
+    """Result of phase 1: parsed experiment structure and module name lists."""
+
+    experiment: FactsExperiment
+    temperature_module_name: Optional[str]
+    sealevel_module_names: List[str]
+    framework_module_names: List[str]
+    esl_module_names: List[str]
+    suppress_output_types: Set[str]
+    workflows: Dict[str, Workflow]
+
+
+@dataclass(frozen=True)
+class _ModuleSpecs:
+    """Result of phase 2: all created ModuleServiceSpec instances."""
+
+    temperature_module: Optional[ModuleServiceSpec]
+    sealevel_modules: Dict[str, ModuleServiceSpec]
+    framework_modules: Dict[str, ModuleServiceSpec]
+    esl_modules: Dict[str, ModuleServiceSpec]
+
+
+def _log_success(msg: str, *args: object) -> None:
+    logger.log(_SUCCESS, msg, *args)
 
 
 def _extract_all_module_names_from_manifest(metadata: Dict[str, Any]) -> List[str]:
@@ -72,7 +118,7 @@ def _module_requires_climate_file(module_name: str) -> bool:
     # Get path
     module_yaml_path = find_module_yaml_path(module_name)
     # Load module yaml
-    module_yaml = load_facts_module_from_yaml(yaml_path=module_yaml_path)
+    module_yaml = load_module_schema_from_yaml(yaml_path=module_yaml_path)
     # Return uses climate file attr
     return module_yaml.uses_climate_file
 
@@ -96,7 +142,7 @@ def _validate_climate_file_inputs(
 
     for module_name in sealevel_modules:
         module_yaml_path = find_module_yaml_path(module_name)
-        module_schema = load_facts_module_from_yaml(yaml_path=module_yaml_path)
+        module_schema = load_module_schema_from_yaml(yaml_path=module_yaml_path)
 
         if not module_schema.uses_climate_file:
             continue
@@ -175,8 +221,9 @@ def _collect_workflow_output_paths_by_type(
             if p and isinstance(p, str) and ot == output_type:
                 # Do not pass through outputs that are components of a larger output unit
                 if p in subregion_strings_to_skip:
-                    print(
-                        f"{p}: This output is a component of a larger unit and is already represented elsewhere; skipping."
+                    logger.info(
+                        "%s: This output is a component of a larger unit and is already represented elsewhere; skipping.",
+                        p,
                     )
                     continue
 
@@ -237,14 +284,14 @@ def _create_facts_total_compose_service(
     service_name: str,
     wf: Workflow,
     metadata: Dict[str, Any],
-    metadata_path: Path,
+    experiment_dir: Path,
     facts_total_yaml_path: Path,
 ) -> Dict[str, Any]:
     """Build the compose service dict for a facts-total workflow from its synthetic section."""
     metadata_copy = dict(metadata)
     metadata_copy[service_name] = section
     wf_module = create_module_service_spec_from_metadata(
-        metadata_path,
+        experiment_dir,
         module_name=service_name,
         module_type="framework_module",
         metadata=metadata_copy,
@@ -257,69 +304,67 @@ def _create_facts_total_compose_service(
     return compose_svc
 
 
-def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
-    """
-    Generate Docker Compose file from experiment metadata.
+def check_metadata_has_required_fields(metadata_obj, required_fields):
+    """This function accepts a list of required fields and a metadata object and subsets the metadata to required fields."""
+    # Subset
+    required_fields_meta = {
+        k: v for k, v in metadata_obj.items() if k in required_fields
+    }
 
-    This is the main orchestration function that:
-    1. Loads metadata (UI layer)
-    2. Parses manifest to determine which modules to include
-    3. Uses parsers (Adapter layer) to create domain objects (modules)
-    4. Generates docker compose services (Engine/Infrastructure layer)
-
-    Args:
-        metadata_path: Path to experiment-config.yaml
-
-    Returns:
-        Complete Docker Compose file dictionary
-    """
-    if not metadata_path.exists():
-        raise FileNotFoundError(
-            f"When trying to read experiment-metadata file to generate corresponding compose file, metadata file not found: {metadata_path}"
-        )
-
-    # Step 1: Load metadata (UI layer)
-    metadata = load_experiment_metadata(metadata_path)
-    # Check that required fields in experient-config have been completed
-    # TODO do this better in future
-    required_fields = [
-        "experiment_name",
-        "pipeline-id",
-        "nsamps",
-        "scenario",
-        "pyear_start",
-        "pyear_end",
-        "pyear_step",
-        "baseyear",
-        "module-specific-input-data",
-        "shared-input-data",
-        "output-data-location",
-    ]
-    # subset metadata to required fields
-    required_fields_meta = {k: v for k, v in metadata.items() if k in required_fields}
-    # raise error if any are missing a value
+    # R aise error if any are missing a value
     for k, v in required_fields_meta.items():
         if v is None:
             raise ValueError(
-                f"A value for {k} is required but none was found. Check that all required fields in this experiment's experiment-config.yml file have been completed."
+                f"A value for {k} is required but none was found. Check that all required fields in this experiment's experiment-config.yml have been completed."
             )
-    experiment_dir = metadata_path.parent
 
-    # Step 2: Build FactsExperiment — derive key sets from module schemas
+    return None
+
+
+def extract_experiment_dir_from_metadata_path(metadata_path):
+    """This function extracts the experiment directory from the metadata path obj"""
+
+    experiment_dir = metadata_path.parent
+    if experiment_dir == metadata_path:
+        raise ValueError(
+            f"No experiment dir found in the parent path of provided metadata path, {metadata_path}"
+        )
+    return experiment_dir
+
+
+def _parse_experiment(metadata: Dict[str, Any]) -> _ExperimentPlan:
+    """Phase 1 of generating compose:
+    Validate metadata and build a typed experiment plan.
+
+    Ths fn is only data transformation, there should be no filesystem I/O beyond module YAML loading.
+    """
+
+    # This should raise an error if user has not completed necessary fields in experiment-config.yaml
+    check_metadata_has_required_fields(
+        metadata_obj=metadata, required_fields=_REQUIRED_FIELDS
+    )
+
+    # Get the list of modules included in experiment from manifest in exp config
     _manifest_module_names = _extract_all_module_names_from_manifest(metadata)
-    _schemas = [load_facts_module_by_name(m) for m in _manifest_module_names]
+
+    # Use list of modules to load schema for each module
+    _schemas = [load_module_schema_by_name(m) for m in _manifest_module_names]
+
+    # Get keys for top level params and fingerprint params from each module in experiment
     _top_level_keys = set(collect_metadata_param_keys(_schemas, "top_level"))
     _fp_keys = set(collect_metadata_param_keys(_schemas, "fingerprint_params"))
+
+    # Create FactsExperiment obj from metadata dict
     experiment = FactsExperiment.from_metadata_dict(
         metadata,
         top_level_keys=_top_level_keys,
         fingerprint_keys=_fp_keys,
     )
-
-    _suppress_output_types: set = (
+    # Set output (local or global) based on user spec. in experiment config
+    suppress_output_types: Set[str] = (
         {"local"} if experiment.projection_scale == "global" else set()
     )
-
+    # Separate module names by step
     temperature_module_name = experiment.climate_step.module_name or "NONE"
     sealevel_module_names = experiment.sealevel_step.module_names
     framework_module_names = (
@@ -332,131 +377,213 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
         if experiment.extreme_sealevel_step.is_present
         else []
     )
-
-    # Step 3: Create ModuleServiceSpec instances using parsers (Adapter layer -> Domain layer)
-    # modules = []
-    modules = {
-        "temperature_module": None,
-        "sealevel_modules": {},
-        "framework_modules": {},
-        "esl_modules": {},
-    }
-
-    # Create temperature module if specified (and not "NONE")
-    if temperature_module_name and temperature_module_name.upper() != "NONE":
-        try:
-            module = create_module_service_spec_from_metadata(
-                metadata_path,
-                module_name=temperature_module_name,
-                module_type="temperature_module",
-                metadata=metadata,
-            )
-            # modules.append(module)
-            modules["temperature_module"] = module
-            print(f"✓ Created {temperature_module_name} module")
-        except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-            print(
-                f"⚠ Warning: Failed to create temp module '{temperature_module_name}': {e}"
-            )
-    elif temperature_module_name and temperature_module_name.upper() == "NONE":
-        # No temperature module - validate that sealevel modules have climate file inputs
-        # Only validate modules that have climate_file_required=True
-        print("ℹ No temperature module specified (NONE)")
-        _validate_climate_file_inputs(metadata, sealevel_module_names, experiment_dir)
-
-    # Create sea level modules if specified
-    for module_name in sealevel_module_names:
-        try:
-            module = create_module_service_spec_from_metadata(
-                metadata_path,
-                module_name=module_name,
-                module_type="sealevel_module",
-                metadata=metadata,
-            )
-            modules["sealevel_modules"][module_name] = module
-            print(f"✓ Created {module_name} module")
-        except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-            print(f"⚠ Warning: Failed to create sealevel module '{module_name}': {e}")
-
-    # Create framework modules if specified (skip per-workflow modules when workflows exist; we add per-workflow services below)
+    # Make workflow obj from metadata
     workflows = workflows_from_metadata(metadata)
-    for module_name in framework_module_names:
-        if _module_is_per_workflow(module_name) and workflows:
-            continue  # per-workflow modules are added once per workflow below
-        try:
-            module = create_module_service_spec_from_metadata(
-                metadata_path,
-                module_name=module_name,
-                module_type="framework_module",
-                metadata=metadata,
-            )
-            modules["framework_modules"][module_name] = module
-            print(f"✓ Created {module_name} module")
-        except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-            print(f"⚠ Warning: Failed to create framework module '{module_name}': {e}")
 
-    # Create ESL modules if specified
-    for module_name in esl_module_names:
-        try:
-            module = create_module_service_spec_from_metadata(
-                metadata_path,
-                module_name=module_name,
-                module_type="extreme_sealevel_module",
-                metadata=metadata,
-            )
-            # modules.append(module)
-            modules["esl_modules"][module_name] = module
-            print(f"✓ Created {module_name} module")
-        except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-            print(f"⚠ Warning: Failed to create ESL module '{module_name}': {e}")
+    # Make an ExperimentPlan obj
+    # (first component of generate compose, used to build module spec objs)
+    return _ExperimentPlan(
+        experiment=experiment,
+        temperature_module_name=temperature_module_name,
+        sealevel_module_names=sealevel_module_names,
+        framework_module_names=framework_module_names,
+        esl_module_names=esl_module_names,
+        suppress_output_types=suppress_output_types,
+        workflows=workflows,
+    )
 
-    if (
-        not modules["temperature_module"]
-        and not modules["sealevel_modules"]
-        and not modules["framework_modules"]
-        and not modules["esl_modules"]
+
+def _build_module_specs(
+    plan: _ExperimentPlan,
+    metadata: Dict[str, Any],
+    experiment_dir: Path,
+) -> _ModuleSpecs:
+    """Phase 2: Create a ModuleServiceSpec for each module in the experiment.
+
+    All filesystem I/O for module YAML loading is isolated here.
+    """
+    temperature_module: Optional[ModuleServiceSpec] = None
+    sealevel_modules: Dict[str, ModuleServiceSpec] = {}
+    framework_modules: Dict[str, ModuleServiceSpec] = {}
+    esl_modules: Dict[str, ModuleServiceSpec] = {}
+
+    if plan.temperature_module_name.upper() != "NONE":
+        temperature_module = create_module_service_spec_from_metadata(
+            experiment_dir,
+            module_name=plan.temperature_module_name,
+            module_type="temperature_module",
+            metadata=metadata,
+        )
+        _log_success("Created %s module", plan.temperature_module_name)
+    else:
+        logger.info("No temperature module specified (NONE)")
+        _validate_climate_file_inputs(
+            metadata, plan.sealevel_module_names, experiment_dir
+        )
+
+    for module_name in plan.sealevel_module_names:
+        sealevel_modules[module_name] = create_module_service_spec_from_metadata(
+            experiment_dir,
+            module_name=module_name,
+            module_type="sealevel_module",
+            metadata=metadata,
+        )
+        _log_success("Created %s module", module_name)
+
+    for module_name in plan.framework_module_names:
+        if _module_is_per_workflow(module_name) and plan.workflows:
+            continue
+        framework_modules[module_name] = create_module_service_spec_from_metadata(
+            experiment_dir,
+            module_name=module_name,
+            module_type="framework_module",
+            metadata=metadata,
+        )
+        _log_success("Created %s module", module_name)
+
+    for module_name in plan.esl_module_names:
+        esl_modules[module_name] = create_module_service_spec_from_metadata(
+            experiment_dir,
+            module_name=module_name,
+            module_type="extreme_sealevel_module",
+            metadata=metadata,
+        )
+        _log_success("Created %s module", module_name)
+
+    # Make _ModuleSpecs obj
+    # This is what's returned by _build_module_specs
+    # and used by _build_compose_servies()
+    specs = _ModuleSpecs(
+        temperature_module=temperature_module,
+        sealevel_modules=sealevel_modules,
+        framework_modules=framework_modules,
+        esl_modules=esl_modules,
+    )
+
+    if not any(
+        [
+            specs.temperature_module,
+            specs.sealevel_modules,
+            specs.framework_modules,
+            specs.esl_modules,
+        ]
     ):
         has_step_data = bool(
             metadata.get("supplied-totaled-sealevel-step-data")
             or metadata.get("experiment-specific-input-data")
         )
-        if has_step_data:
-            print(
-                "ℹ All experiment steps use pre-existing data. No Docker services to generate."
+        if not has_step_data:
+            raise ValueError(
+                "No modules could be created from metadata. "
+                "Please ensure at least one module is specified and has valid configuration."
             )
-            return {"services": {}}
-        raise ValueError(
-            "No modules could be created from metadata. "
-            "Please ensure at least one module is specified and has valid configuration."
+        logger.info(
+            "All experiment steps use pre-existing data. No Docker services to generate."
         )
 
-    # Step 4: Generate Docker Compose services (Engine/Infrastructure layer)
-    services = {}
+    return specs
 
-    # Add temperature module service if present
-    temperature_module = modules["temperature_module"]
-    temperature_module_name = (
-        temperature_module.module_name if temperature_module else None
+
+def _create_esl_workflow_services(
+    esl_module_names: List[str],
+    workflows: Dict[str, Workflow],
+    metadata: Dict[str, Any],
+    experiment_dir: Path,
+    projection_scale: Optional[str],
+) -> Dict[str, Any]:
+    """Build one ESL compose service per workflow, keyed by service name."""
+    services: Dict[str, Any] = {}
+    if not esl_module_names:
+        return services
+    if projection_scale == "global":
+        logger.info("Skipping per-workflow ESL services (projection_scale=global)")
+        return services
+
+    for esl_module_name in esl_module_names:
+        try:
+            esl_yaml_path = find_module_yaml_path(esl_module_name)
+        except FileNotFoundError:
+            logger.warning(
+                "ESL module YAML not found for '%s', skipping per-workflow ESL",
+                esl_module_name,
+            )
+            continue
+        base_section = metadata.get(esl_module_name) or {}
+        if not isinstance(base_section, dict):
+            base_section = {}
+        try:
+            exp_paths = get_experiment_paths(metadata, f"{esl_module_name} module")
+            module_specific_base = expand_path(
+                exp_paths.get("module_specific_input_data"),
+                "module-specific-input-data",
+            )
+        except (KeyError, TypeError):
+            module_specific_base = ""
+        for _wf_name, wf in workflows.items():
+            service_name = f"{esl_module_name}-{wf.name}"
+            base_inputs = dict(base_section.get("inputs") or {})
+            base_inputs["total_localsl_file"] = wf.total_localsl_path_under_output
+            gesla_val = base_inputs.get("gesla_dir")
+            if not gesla_val or (
+                isinstance(gesla_val, dict) and gesla_val.get("value") in (None, "")
+            ):
+                if module_specific_base:
+                    base_inputs["gesla_dir"] = (
+                        f"{module_specific_base}/{esl_module_name}/gesla_data"
+                    )
+            base_outputs = base_section.get("outputs") or {}
+            synthetic_section = {
+                **base_section,
+                "inputs": base_inputs,
+                "outputs": {**base_outputs, "output-dir": "."},
+            }
+            metadata_copy = dict(metadata)
+            metadata_copy[service_name] = synthetic_section
+            esl_module = create_module_service_spec_from_metadata(
+                experiment_dir,
+                module_name=service_name,
+                module_type="extreme_sealevel_module",
+                metadata=metadata_copy,
+                module_yaml_path=esl_yaml_path,
+            )
+            compose_svc = esl_module.generate_compose_service()
+            compose_svc["depends_on"] = {
+                wf.facts_total_service_name_for_type("local"): {
+                    "condition": "service_completed_successfully"
+                }
+            }
+            services[service_name] = compose_svc
+            _log_success("Created %s ESL workflow service", service_name)
+    return services
+
+
+def _build_compose_services(
+    specs: _ModuleSpecs,
+    plan: _ExperimentPlan,
+    metadata: Dict[str, Any],
+    experiment_dir: Path,
+) -> Dict[str, Any]:
+    """Phase 3: Render ModuleServiceSpecs into Docker Compose service dicts."""
+    services: Dict[str, Any] = {}
+
+    temperature_service_name = (
+        specs.temperature_module.module_name if specs.temperature_module else None
     )
-
-    if temperature_module:
-        services[temperature_module_name] = (
-            temperature_module.generate_compose_service()
+    if specs.temperature_module:
+        services[temperature_service_name] = (
+            specs.temperature_module.generate_compose_service()
         )
 
-    # Add sealevel modules directly to services (flat structure for Docker Compose)
-    for module_name, module in modules["sealevel_modules"].items():
+    for _module_name, module in specs.sealevel_modules.items():
         service_name = module.module_name
-        compose_service = module.generate_compose_service(
-            temperature_service_name=temperature_module_name,
-            suppress_output_types=_suppress_output_types,
+        services[service_name] = module.generate_compose_service(
+            temperature_service_name=temperature_service_name,
+            suppress_output_types=plan.suppress_output_types,
         )
-        services[service_name] = compose_service
 
-    # Add one facts-total service per workflow (after sealevel services)
-    if workflows:
+    if plan.workflows:
         per_workflow_fw = [
-            m for m in framework_module_names if _module_is_per_workflow(m)
+            m for m in plan.framework_module_names if _module_is_per_workflow(m)
         ]
         facts_total_name = per_workflow_fw[0] if per_workflow_fw else "facts-total"
         facts_total_yaml_path = find_module_yaml_path(facts_total_name)
@@ -465,13 +592,17 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
         facts_total_image = facts_total_config.get(
             "container_image", "ghcr.io/fact-sealevel/facts-total:v0.1.2"
         )
-        for wf_name, wf in workflows.items():
+        for wf_name, wf in plan.workflows.items():
             for output_type in facts_total_config.get(
                 "output_types", ["global", "local"]
             ):
-                if output_type == "local" and experiment.projection_scale == "global":
-                    print(
-                        f"ℹ Skipping local facts-total for {wf_name} (projection_scale=global)"
+                if (
+                    output_type == "local"
+                    and plan.experiment.projection_scale == "global"
+                ):
+                    logger.info(
+                        "Skipping local facts-total for %s (projection_scale=global)",
+                        wf_name,
                     )
                     continue
                 section = _build_facts_total_section_for_workflow(
@@ -482,101 +613,84 @@ def generate_compose_from_metadata(metadata_path: Path) -> Dict[str, Any]:
                 else:
                     _populate_section_with_local_outputs(section, metadata, wf)
                 service_name = wf.facts_total_service_name_for_type(output_type)
-                try:
-                    compose_svc = _create_facts_total_compose_service(
-                        section,
-                        service_name,
-                        wf,
-                        metadata,
-                        metadata_path,
-                        facts_total_yaml_path,
-                    )
-                    services[service_name] = compose_svc
-                    print(f"✓ Created {service_name} workflow service")
-                except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-                    print(
-                        f"⚠ Warning: Failed to create workflow service '{service_name}': {e}"
-                    )
+                compose_svc = _create_facts_total_compose_service(
+                    section,
+                    service_name,
+                    wf,
+                    metadata,
+                    experiment_dir,
+                    facts_total_yaml_path,
+                )
+                services[service_name] = compose_svc
+                _log_success("Created %s workflow service", service_name)
 
-        # One ESL service per workflow when both workflows and esl_modules are specified
-        if esl_module_names and experiment.projection_scale == "global":
-            print("ℹ Skipping per-workflow ESL services (projection_scale=global)")
-        elif esl_module_names:
-            for esl_module_name in esl_module_names:
-                try:
-                    esl_yaml_path = find_module_yaml_path(esl_module_name)
-                except FileNotFoundError:
-                    print(
-                        f"⚠ Warning: ESL module YAML not found for '{esl_module_name}', skipping per-workflow ESL"
-                    )
-                    continue
-                base_section = metadata.get(esl_module_name) or {}
-                if not isinstance(base_section, dict):
-                    base_section = {}
-                # Resolve module-specific input base so we can set gesla_dir when it's a placeholder
-                try:
-                    exp_paths = get_experiment_paths(
-                        metadata, f"{esl_module_name} module"
-                    )
-                    module_specific_base = expand_path(
-                        exp_paths.get("module_specific_input_data"),
-                        "module-specific-input-data",
-                    )
-                except (KeyError, TypeError):
-                    module_specific_base = ""
-                for wf_name, wf in workflows.items():
-                    service_name = f"{esl_module_name}-{wf.name}"
-                    base_inputs = dict(base_section.get("inputs") or {})
-                    base_inputs["total_localsl_file"] = (
-                        wf.total_localsl_path_under_output
-                    )
-                    # Ensure gesla_dir is a valid path so --gesla-dir appears in the compose command
-                    gesla_val = base_inputs.get("gesla_dir")
-                    if not gesla_val or (
-                        isinstance(gesla_val, dict)
-                        and gesla_val.get("value") in (None, "")
-                    ):
-                        if module_specific_base:
-                            base_inputs["gesla_dir"] = (
-                                f"{module_specific_base}/{esl_module_name}/gesla_data"
-                            )
-                    base_outputs = base_section.get("outputs") or {}
-                    synthetic_section = {
-                        **base_section,
-                        "inputs": base_inputs,
-                        "outputs": {**base_outputs, "output-dir": "."},
-                    }
-                    metadata_copy = dict(metadata)
-                    metadata_copy[service_name] = synthetic_section
-                    try:
-                        esl_module = create_module_service_spec_from_metadata(
-                            metadata_path,
-                            module_name=service_name,
-                            module_type="extreme_sealevel_module",
-                            metadata=metadata_copy,
-                            module_yaml_path=esl_yaml_path,
-                        )
-                        compose_svc = esl_module.generate_compose_service()
-                        compose_svc["depends_on"] = {
-                            wf.facts_total_service_name_for_type("local"): {
-                                "condition": "service_completed_successfully"
-                            }
-                        }
-                        services[service_name] = compose_svc
-                        print(f"✓ Created {service_name} ESL workflow service")
-                    except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
-                        print(
-                            f"⚠ Warning: Failed to create ESL workflow service '{service_name}': {e}"
-                        )
+        services.update(
+            _create_esl_workflow_services(
+                plan.esl_module_names,
+                plan.workflows,
+                metadata,
+                experiment_dir,
+                plan.experiment.projection_scale,
+            )
+        )
 
-    # When there are no workflows, add a single ESL service per ESL module
-    if not workflows and experiment.projection_scale != "global":
-        for _esl_name, esl_module in modules["esl_modules"].items():
+    if not plan.workflows and plan.experiment.projection_scale != "global":
+        for _esl_name, esl_module in specs.esl_modules.items():
             service_name = esl_module.module_name
             services[service_name] = esl_module.generate_compose_service()
-            print(f"✓ Created {service_name} module")
+            _log_success("Created %s module", service_name)
 
-    # Step 5: Build complete Docker Compose file as dict
-    compose_dict = {"services": services}
+    return services
 
-    return compose_dict
+
+def generate_compose(metadata: Dict[str, Any], experiment_dir: Path) -> Dict[str, Any]:
+    """
+    Generate Docker Compose dict from already-loaded experiment metadata.
+
+    Use this when metadata is already loaded (e.g. from a notebook or test).
+    For path-based callers, use generate_compose_from_path().
+
+    Args:
+        metadata: Loaded experiment-config.yaml as a dict
+        experiment_dir: Path to the experiment directory
+
+    Returns:
+        Complete Docker Compose file dictionary
+    """
+    plan = _parse_experiment(metadata)
+    specs = _build_module_specs(plan, metadata, experiment_dir)
+    if not any(
+        [
+            specs.temperature_module,
+            specs.sealevel_modules,
+            specs.framework_modules,
+            specs.esl_modules,
+        ]
+    ):
+        return {"services": {}}
+    services = _build_compose_services(specs, plan, metadata, experiment_dir)
+    return {"services": services}
+
+
+def generate_compose_from_path(metadata_path: Path) -> Dict[str, Any]:
+    """
+    Generate Docker Compose dict from a path to experiment-config.yaml.
+
+    Handles I/O setup then delegates to generate_compose().
+    For callers with metadata already loaded, use generate_compose() directly.
+
+    Args:
+        metadata_path: Path to experiment-config.yaml
+
+    Returns:
+        Complete Docker Compose file dictionary
+    """
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"When trying to read experiment-metadata file to generate corresponding "
+            f"compose file, metadata file not found: {metadata_path}"
+        )
+    ModuleRegistry.default()
+    metadata = load_experiment_metadata(metadata_path)
+    experiment_dir = metadata_path.parent
+    return generate_compose(metadata, experiment_dir)

--- a/src/facts_experiment_builder/application/setup_experiment.py
+++ b/src/facts_experiment_builder/application/setup_experiment.py
@@ -24,7 +24,7 @@ from facts_experiment_builder.core.steps import (
     ExtremeSealevelStep,
 )
 from facts_experiment_builder.infra.module_loader import (
-    load_facts_module_by_name,
+    load_module_schema_by_name,
 )
 from facts_experiment_builder.infra.experiment_manager import (
     resolve_experiment_directory_path,
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 def _climate_output_file_path(climate_module_name: str) -> Optional[str]:
     """Return the output climate file path for a climate module (e.g. 'fair-temperature/climate.nc')."""
-    schema = load_facts_module_by_name(climate_module_name)
+    schema = load_module_schema_by_name(climate_module_name)
     for output in schema.get_file_outputs():
         if output.get("name") == "output-climate-file":
             filename = output.get("filename", "climate.nc")
@@ -63,7 +63,7 @@ def hydrate_sealevel_step(
 ) -> SealevelStep:
     if skeleton.sealevel_modules:
         sealevel_schemas = [
-            load_facts_module_by_name(m) for m in skeleton.sealevel_modules
+            load_module_schema_by_name(m) for m in skeleton.sealevel_modules
         ]
         sealevel_step = SealevelStep.from_module_schemas(
             sealevel_schemas,
@@ -89,7 +89,7 @@ def hydrate_experiment(
     """
     if skeleton.climate_module and skeleton.climate_module.upper() != "NONE":
         climate_step = ClimateStep.from_module_schema(
-            load_facts_module_by_name(skeleton.climate_module)
+            load_module_schema_by_name(skeleton.climate_module)
         )
     elif skeleton.supplied_totaled_sealevel_step_data:
         climate_step = ClimateStep.not_needed()
@@ -100,14 +100,14 @@ def hydrate_experiment(
 
     if skeleton.totaling_module:
         totaling_step = TotalingStep.from_module_schema(
-            load_facts_module_by_name(skeleton.totaling_module)
+            load_module_schema_by_name(skeleton.totaling_module)
         )
     else:
         totaling_step = TotalingStep()
 
     if skeleton.extremesealevel_module:
         extreme_sealevel_step = ExtremeSealevelStep.from_module_schema(
-            load_facts_module_by_name(skeleton.extremesealevel_module)
+            load_module_schema_by_name(skeleton.extremesealevel_module)
         )
     else:
         extreme_sealevel_step = ExtremeSealevelStep()
@@ -166,7 +166,7 @@ def experiment_skeleton_to_facts_experiment(
     # validate skeleton first
     validate_skeleton_modules(skeleton)
     # Load schemas to derive which top-level and fingerprint keys this experiment needs
-    schemas = [load_facts_module_by_name(m) for m in skeleton.all_module_names]
+    schemas = [load_module_schema_by_name(m) for m in skeleton.all_module_names]
     # Lookup table mapping schema key names (kebab and snake) to CLI-provided values
     cli_values: Dict[str, object] = {
         "pipeline-id": pipeline_id,

--- a/src/facts_experiment_builder/cli/generate_compose_cli.py
+++ b/src/facts_experiment_builder/cli/generate_compose_cli.py
@@ -2,7 +2,7 @@ import click
 from pathlib import Path
 from facts_experiment_builder.cli.theme import console
 from facts_experiment_builder.application.generate_compose import (
-    generate_compose_from_metadata,
+    generate_compose_from_path,
 )
 from facts_experiment_builder.infra.path_manager import (
     find_experiment_metadata_file,
@@ -15,7 +15,34 @@ from facts_experiment_builder.infra.write_compose import (
 import logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+
+
+_SUCCESS = 25  # must match application layer value
+logging.addLevelName(_SUCCESS, "SUCCESS")
+
+
+class _ClickEchoHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = record.getMessage()
+        if record.levelno >= logging.WARNING:
+            console.print(f"⚠ [danger]Warning: [/danger]{msg}")
+        elif record.levelno == _SUCCESS:
+            console.print(f"✓ [success]{msg}[/success]")
+        else:  # INFO
+            console.print(f"ℹ [accent]{msg}[/accent]")
+
+
+def _configure_feb_logging() -> None:
+    """Wire the ClickEchoHandler onto the facts_experiment_builder namespace logger.
+
+    Called at CLI invocation time (not import time) so that tests importing from
+    sibling modules don't accidentally install the handler and break caplog capture.
+    """
+    feb_logger = logging.getLogger("facts_experiment_builder")
+    if not any(isinstance(h, _ClickEchoHandler) for h in feb_logger.handlers):
+        feb_logger.addHandler(_ClickEchoHandler())
+    feb_logger.setLevel(logging.INFO)
+    feb_logger.propagate = False
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -44,6 +71,8 @@ def main(
 ) -> None:
     """Generate Docker Compose file from experiment metadata."""
 
+    _configure_feb_logging()
+
     if debug:
         logger.setLevel(logging.INFO)
 
@@ -63,7 +92,11 @@ def main(
     console.print(
         "[primary]Step 2:[/primary] Building compose dictionary from metadata..."
     )
-    compose_dict = generate_compose_from_metadata(metadata_path)
+    try:
+        compose_dict = generate_compose_from_path(metadata_path)
+    except (FileNotFoundError, ValueError) as e:
+        console.print(f"[red]✗ Failed to generate compose file:[/red] {e}")
+        raise SystemExit(1)
 
     # Step 3: Resolve output path for compose file
     console.print(

--- a/src/facts_experiment_builder/core/module/module_service_spec.py
+++ b/src/facts_experiment_builder/core/module/module_service_spec.py
@@ -81,7 +81,6 @@ class ModuleServiceSpec:
     @property
     def input_paths(self) -> ModuleInputPaths:
         """Return input paths (module-specific and general dirs)."""
-        print("input paths: ", self.components.input_paths)
         return self.components.input_paths
 
     @property
@@ -142,6 +141,7 @@ class ModuleServiceSpec:
             if arg_spec.get("envvar"):
                 continue
             value = self._process_argument(arg_spec)
+
             if value is not None:
                 # Handle multiple inputs (e.g., --item can be specified multiple times)
                 if arg_spec.get("multiple", False):
@@ -240,7 +240,10 @@ class ModuleServiceSpec:
                 return value.path
             if value.kind == "experiment_specific_in":
                 return f"/mnt/experiment_specific_in/{Path(value.path).name}"
-            return self._host_path_to_container(value.path, arg_spec)
+            result = self._host_path_to_container(value.path, arg_spec)
+            if value.kind == "host_dir":
+                return result.rstrip("/") + "/"
+            return result
         if mount and isinstance(value, list) and len(value) > 0:
             if all(isinstance(v, TypedPath) for v in value):
                 if value[0].kind == "container":

--- a/src/facts_experiment_builder/core/registry/module_registry.py
+++ b/src/facts_experiment_builder/core/registry/module_registry.py
@@ -1,8 +1,11 @@
 import subprocess
-import warnings
+import logging
 import os
+from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class ModuleRegistry:
@@ -15,20 +18,7 @@ class ModuleRegistry:
 
     @classmethod
     def default(cls) -> "ModuleRegistry":
-        env_dir = os.environ.get("FEB_MODULE_REGISTRY_DIR")
-        if env_dir:
-            return cls(Path(env_dir))
-        workspace_dir = Path.cwd() / "facts-module-registry"
-        if workspace_dir.exists():
-            _warn_if_registry_dirty(workspace_dir)
-            _warn_if_registry_behind(workspace_dir)
-            return cls(workspace_dir)
-        raise FileNotFoundError(
-            f"Module registry not found. Expected facts-module-registry/ in your "
-            f"project workspace ({Path.cwd()}).\n"
-            f"Clone it with:\n"
-            f"  git clone https://github.com/fact-sealevel/facts-module-registry.git"
-        )
+        return _get_default_registry()
 
     def get_module_yaml_path(self, module_name: str) -> Path:
         """Return path to <module_name>/<snake>_module.yaml in the registry."""
@@ -75,20 +65,38 @@ class ModuleRegistry:
         return [d.name for d in self._registry_dir.iterdir() if d.is_dir()]
 
 
-def _warn_if_registry_behind(registry_dir: Path) -> None:
-    """Warn if the local registry clone is behind its remote tracking branch.
+@lru_cache(maxsize=1)
+def _get_default_registry() -> "ModuleRegistry":
+    """Return the default ModuleRegistry, cached for the lifetime of the process.
+
+    Git health checks (_warn_if_registry_dirty, _warn_if_registry_behind) run
+    exactly once. Call .cache_clear() in tests that change the working directory
+    between cases.
+    """
+    env_dir = os.environ.get("FEB_MODULE_REGISTRY_DIR")
+    if env_dir:
+        return ModuleRegistry(Path(env_dir))
+    workspace_dir = Path.cwd() / "facts-module-registry"
+    if workspace_dir.exists():
+        _warn_if_registry_dirty(workspace_dir)
+        _warn_if_registry_behind(workspace_dir)
+        return ModuleRegistry(workspace_dir)
+    raise FileNotFoundError(
+        f"Module registry not found. Expected facts-module-registry/ in your "
+        f"project workspace ({Path.cwd()}).\n"
+        f"Clone it with:\n"
+        f"  git clone https://github.com/fact-sealevel/facts-module-registry.git"
+    )
+
+
+def _check_if_registry_behind(registry_dir: Path) -> None:
+    """Check if local registry is behind remote.
 
     Runs `git fetch` (no explicit remote name) so that all configured remotes
     are contacted and all tracking refs are updated — regardless of whether the
     remote is named 'origin', 'upstream', or anything else. Then compares HEAD
     to @{u} (the upstream tracking branch) using `git rev-list HEAD..@{u}
-    --count`. If the count is non-zero the user is warned with the number of
-    commits they are behind. If the fetch fails (timeout, git unavailable, or
-    other OS error) a warning is emitted with the underlying error so the user
-    knows the check could not be completed. A non-zero rev-list return code
-    (e.g. no upstream tracking branch configured) is treated as up-to-date and
-    produces no warning.
-    """
+    --count`."""
     try:
         subprocess.run(
             ["git", "fetch"],
@@ -98,10 +106,7 @@ def _warn_if_registry_behind(registry_dir: Path) -> None:
             timeout=5,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-        warnings.warn(
-            f"Could not check facts-module-registry for updates: {e}",
-            stacklevel=4,
-        )
+        logger.warning("Could not check facts-module-registry for updates: %s", e)
         return
 
     result = subprocess.run(
@@ -110,29 +115,51 @@ def _warn_if_registry_behind(registry_dir: Path) -> None:
         capture_output=True,
         text=True,
     )
+    return result
+
+
+def _warn_if_registry_behind(registry_dir: Path) -> None:
+    """Warn if the local registry clone is behind its remote tracking branch.
+
+    If the count is non-zero the user is warned with the number of commits they
+    are behind. If the fetch fails (timeout, git unavailable, or other OS error)
+    a warning is emitted by _check_if_registry_behind and None is returned here —
+    in that case we return early. A non-zero rev-list return code (e.g. no
+    upstream tracking branch configured) is treated as up-to-date and produces
+    no warning.
+    """
+    result = _check_if_registry_behind(registry_dir=registry_dir)
+
+    if result is None:
+        return  # warning already emitted by _check_if_registry_behind
+
     if result.returncode == 0 and result.stdout.strip().isdigit():
         count = int(result.stdout.strip())
         if count > 0:
-            warnings.warn(
-                f"facts-module-registry at {registry_dir} is {count} commit(s) behind the remote. "
+            logger.warning(
+                "facts-module-registry at %s is %d commit(s) behind the remote. "
                 "Run `git pull` in that directory to update.",
-                stacklevel=4,
+                registry_dir,
+                count,
             )
+
+
+def _check_if_registry_dirty(registry_dir: Path) -> None:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=registry_dir,
+        capture_output=True,
+        text=True,
+    )
+    return result
 
 
 def _warn_if_registry_dirty(registry_dir: Path) -> None:
-    try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=registry_dir,
-            capture_output=True,
-            text=True,
+    result = _check_if_registry_dirty(registry_dir=registry_dir)
+
+    if result.returncode == 0 and result.stdout.strip():
+        logger.warning(
+            "facts-module-registry at %s has uncommitted changes. "
+            "Module definitions may differ from the published registry.",
+            registry_dir,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            warnings.warn(
-                f"facts-module-registry at {registry_dir} has uncommitted changes. "
-                "Module definitions may differ from the published registry.",
-                stacklevel=4,
-            )
-    except Exception:
-        pass

--- a/src/facts_experiment_builder/core/typed_path.py
+++ b/src/facts_experiment_builder/core/typed_path.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import List, Literal, Union
 
-PathKind = Literal["host", "container", "experiment_specific_in"]
+PathKind = Literal["host", "host_dir", "container", "experiment_specific_in"]
 
 
 @dataclass(frozen=True)
@@ -13,6 +13,9 @@ class TypedPath:
     Kinds:
     - "host": host path routed to a standard module input volume; container destination
       determined by the module YAML mount spec.
+    - "host_dir": host path to a directory; like "host" but the builder appends a
+      trailing slash to the container path. Use for inputs declared type: "dir" in the
+      module YAML (e.g. zosdir, model-dir).
     - "container": already a container path; used as-is.
     - "experiment_specific_in": host path for user-supplied experiment data (e.g.
       climate data passed via --supplied-climate-step-data); always routed to
@@ -29,6 +32,11 @@ class TypedPath:
 def HostPath(path: str) -> TypedPath:
     """Path on the host filesystem; builder will rewrite to container path via module YAML mount spec."""
     return TypedPath(path=path, kind="host")
+
+
+def HostDirPath(path: str) -> TypedPath:
+    """Host path to a directory; builder rewrites to container path and appends a trailing slash."""
+    return TypedPath(path=path, kind="host_dir")
 
 
 def ContainerPath(path: str) -> TypedPath:

--- a/src/facts_experiment_builder/infra/module_loader.py
+++ b/src/facts_experiment_builder/infra/module_loader.py
@@ -5,7 +5,7 @@ from facts_experiment_builder.infra.path_manager import find_module_yaml_path
 from facts_experiment_builder.infra.exceptions import ModuleYamlNotFoundError
 
 
-def load_facts_module_from_yaml(yaml_path: Path) -> ModuleSchema:
+def load_module_schema_from_yaml(yaml_path: Path) -> ModuleSchema:
     """
     Load a ModuleSchema from a module YAML file.
 
@@ -23,7 +23,7 @@ def load_facts_module_from_yaml(yaml_path: Path) -> ModuleSchema:
     return ModuleSchema.from_dict(data)
 
 
-def load_facts_module_by_name(module_name: str) -> ModuleSchema:
+def load_module_schema_by_name(module_name: str) -> ModuleSchema:
     """
     Load a ModuleSchema by module name (resolve path then load).
 
@@ -35,4 +35,4 @@ def load_facts_module_by_name(module_name: str) -> ModuleSchema:
         ModuleSchema for the module.
     """
     yaml_path = find_module_yaml_path(module_name)
-    return load_facts_module_from_yaml(yaml_path)
+    return load_module_schema_from_yaml(yaml_path)

--- a/src/facts_experiment_builder/infra/write_experiment_metadata.py
+++ b/src/facts_experiment_builder/infra/write_experiment_metadata.py
@@ -157,6 +157,9 @@ def format_module_value(key: str, value: Any, indent: int = 2) -> List[str]:
                 )
     elif isinstance(value, dict):
         # Regular nested dict (like inputs, options, outputs sections)
+        if not value:
+            lines.append(f"{indent_str}{key}: {{}}")
+            return lines
         lines.append(f"{indent_str}{key}:")
         for nested_key, nested_value in value.items():
             if nested_key.startswith("#"):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 REGISTRY_SOURCE = REPO_ROOT / "facts-module-registry"
 
 
+@pytest.fixture(autouse=True)
+def registry_env(monkeypatch):
+    """Point the registry at the real source via env var for all integration tests.
+
+    Using FEB_MODULE_REGISTRY_DIR bypasses the git health checks (no warnings
+    in tests) and always resolves to a stable path, so the lru_cache on
+    _get_default_registry never goes stale between test cases.
+    """
+    monkeypatch.setenv("FEB_MODULE_REGISTRY_DIR", str(REGISTRY_SOURCE))
+
+
 ## shared fixtures
 @pytest.fixture
 def experiment_name():
@@ -19,9 +30,6 @@ def project_root(tmp_path):
             "facts-module-registry not present — clone it to run integration tests"
         )
     (tmp_path / "experiments").mkdir()
-    (tmp_path / "facts-module-registry").symlink_to(
-        REGISTRY_SOURCE, target_is_directory=True
-    )
     return tmp_path
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,23 @@
 """Shared fixtures for unit tests."""
 
+import logging
 import pytest
 from pathlib import Path
 from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def reset_feb_logger():
+    """Reset facts_experiment_builder logger state between tests.
+
+    _configure_feb_logging() (called by CLI tests) sets propagate=False on the
+    facts_experiment_builder logger. This persists across tests in the same session
+    and prevents caplog from capturing log records in later tests.
+    """
+    yield
+    logger = logging.getLogger("facts_experiment_builder")
+    logger.propagate = True
+    logger.handlers.clear()
 
 
 @pytest.fixture

--- a/tests/unit/test_generate_compose.py
+++ b/tests/unit/test_generate_compose.py
@@ -2,7 +2,10 @@
 
 import pytest
 from facts_experiment_builder.application import generate_compose
-from unittest.mock import patch
+from facts_experiment_builder.application.generate_compose import (
+    check_metadata_has_required_fields,
+)
+from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 
@@ -141,3 +144,128 @@ def test_collect_workflow_output_paths_local_only():
     )
     assert len(paths) == 1
     assert "lslr.nc" in paths[0]
+
+
+def test_check_metadata_has_required_fields():
+    required_fields = {
+        "experiment-name": "my-test-exp",
+        "pipeline-id": "abc123",
+        "nsamps": 100,
+    }
+    metadata_complete = {
+        "experiment-name": "my-test-exp",
+        "pipeline-id": "abc123",
+        "nsamps": 100,
+        "scenario": "ssp585",
+    }
+    metadata_incomplete = {
+        "pipeline-id": "abc123",
+        "nsamps": 100,
+        "experiment-name": None,
+    }
+    check_metadata_has_required_fields(metadata_complete, required_fields)
+
+    with pytest.raises(ValueError, match="experiment-name"):
+        check_metadata_has_required_fields(
+            metadata_incomplete, required_fields=["experiment-name"]
+        )
+
+
+def test_extract_experiment_dir_from_metadata_path():
+    metadata_path = Path("/experiments/my-exp/experiment-config.yaml")
+    result = generate_compose.extract_experiment_dir_from_metadata_path(metadata_path)
+    assert result == Path("/experiments/my-exp")
+
+
+def test_extract_experiment_dir_raises_for_root_path():
+    with pytest.raises(ValueError, match="No experiment dir"):
+        generate_compose.extract_experiment_dir_from_metadata_path(Path("/"))
+
+
+def test_extract_all_module_names_returns_all_modules():
+    metadata = {
+        "temperature_module": "fair-temperature",
+        "sealevel_modules": ["bamber19-icesheets", "tlm-sterodynamics"],
+        "framework_modules": ["facts-total"],
+        "esl_modules": ["extremesealevel-pointsoverthreshold"],
+    }
+    result = generate_compose._extract_all_module_names_from_manifest(metadata)
+    assert result == [
+        "fair-temperature",
+        "bamber19-icesheets",
+        "tlm-sterodynamics",
+        "facts-total",
+        "extremesealevel-pointsoverthreshold",
+    ]
+
+
+def test_extract_all_module_names_excludes_none_temperature():
+    metadata = {
+        "temperature_module": "NONE",
+        "sealevel_modules": ["tlm-sterodynamics"],
+        "framework_modules": [],
+        "esl_modules": [],
+    }
+    result = generate_compose._extract_all_module_names_from_manifest(metadata)
+    assert result == ["tlm-sterodynamics"]
+
+
+def test_extract_all_module_names_excludes_lowercase_none_temperature():
+    metadata = {"temperature_module": "none", "sealevel_modules": ["tlm-sterodynamics"]}
+    result = generate_compose._extract_all_module_names_from_manifest(metadata)
+    assert result == ["tlm-sterodynamics"]
+
+
+def test_extract_all_module_names_empty_metadata():
+    result = generate_compose._extract_all_module_names_from_manifest({})
+    assert result == []
+
+
+def test_parse_experiment_returns_plan_with_correct_module_names():
+    """_parse_experiment is independently testable — no filesystem needed beyond patching the module loader."""
+    metadata = {
+        "experiment_name": "test-exp",
+        "pipeline-id": "abc123",
+        "nsamps": 100,
+        "scenario": "ssp585",
+        "pyear_start": 2020,
+        "pyear_end": 2100,
+        "pyear_step": 10,
+        "baseyear": 2005,
+        "module-specific-input-data": "/data/module",
+        "shared-input-data": "/data/shared",
+        "output-data-location": "/data/output",
+        "temperature_module": "fair-temperature",
+        "sealevel_modules": ["tlm-sterodynamics"],
+    }
+
+    mock_experiment = MagicMock()
+    mock_experiment.climate_step.module_name = "fair-temperature"
+    mock_experiment.sealevel_step.module_names = ["tlm-sterodynamics"]
+    mock_experiment.totaling_step.is_present = False
+    mock_experiment.totaling_step.module_name = None
+    mock_experiment.extreme_sealevel_step.is_present = False
+    mock_experiment.extreme_sealevel_step.module_name = None
+    mock_experiment.projection_scale = None
+
+    with (
+        patch(
+            "facts_experiment_builder.application.generate_compose.load_module_schema_by_name",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "facts_experiment_builder.application.generate_compose.FactsExperiment.from_metadata_dict",
+            return_value=mock_experiment,
+        ),
+        patch(
+            "facts_experiment_builder.application.generate_compose.workflows_from_metadata",
+            return_value={},
+        ),
+    ):
+        plan = generate_compose._parse_experiment(metadata)
+
+    assert plan.temperature_module_name == "fair-temperature"
+    assert plan.sealevel_module_names == ["tlm-sterodynamics"]
+    assert plan.framework_module_names == []
+    assert plan.esl_module_names == []
+    assert plan.workflows == {}

--- a/tests/unit/test_generate_compose_cli.py
+++ b/tests/unit/test_generate_compose_cli.py
@@ -1,0 +1,82 @@
+"""Tests for generate_compose_cli error handling."""
+
+from unittest.mock import patch
+from click.testing import CliRunner
+
+from facts_experiment_builder.cli.generate_compose_cli import main
+
+runner = CliRunner()
+
+
+def _invoke(experiment_name="my-exp"):
+    return runner.invoke(main, ["--experiment-name", experiment_name])
+
+
+def test_file_not_found_error_exits_nonzero():
+    """A FileNotFoundError from generate_compose_from_path exits with code 1."""
+    with (
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.find_experiment_metadata_file",
+            return_value="/fake/path/experiment-config.yaml",
+        ),
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.generate_compose_from_path",
+            side_effect=FileNotFoundError("metadata file not found: /fake/path"),
+        ),
+    ):
+        result = _invoke()
+
+    assert result.exit_code == 1
+
+
+def test_file_not_found_error_prints_message():
+    """A FileNotFoundError prints a user-facing failure message."""
+    with (
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.find_experiment_metadata_file",
+            return_value="/fake/path/experiment-config.yaml",
+        ),
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.generate_compose_from_path",
+            side_effect=FileNotFoundError("metadata file not found: /fake/path"),
+        ),
+    ):
+        result = _invoke()
+
+    assert "Failed to generate compose file" in result.output
+
+
+def test_value_error_exits_nonzero():
+    """A ValueError from generate_compose_from_path exits with code 1."""
+    with (
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.find_experiment_metadata_file",
+            return_value="/fake/path/experiment-config.yaml",
+        ),
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.generate_compose_from_path",
+            side_effect=ValueError("No modules could be created from metadata"),
+        ),
+    ):
+        result = _invoke()
+
+    assert result.exit_code == 1
+
+
+def test_value_error_prints_message():
+    """A ValueError prints a user-facing failure message including the error detail."""
+    error_detail = "No modules could be created from metadata"
+    with (
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.find_experiment_metadata_file",
+            return_value="/fake/path/experiment-config.yaml",
+        ),
+        patch(
+            "facts_experiment_builder.cli.generate_compose_cli.generate_compose_from_path",
+            side_effect=ValueError(error_detail),
+        ),
+    ):
+        result = _invoke()
+
+    assert "Failed to generate compose file" in result.output
+    assert error_detail in result.output

--- a/tests/unit/test_module_adapter.py
+++ b/tests/unit/test_module_adapter.py
@@ -1,0 +1,28 @@
+"""Tests for the module_adapter module."""
+
+from unittest.mock import MagicMock, patch
+
+from facts_experiment_builder.adapters.module_adapter import (
+    create_module_service_spec_from_metadata,
+)
+
+
+def test_create_module_service_spec_accepts_path_experiment_dir(tmp_path):
+    """experiment_dir must be a Path; regression test for the str annotation bug."""
+    with (
+        patch(
+            "facts_experiment_builder.adapters.module_adapter.load_experiment_metadata",
+            return_value={"temperature_module": "fair-temperature"},
+        ) as mock_load,
+        patch(
+            "facts_experiment_builder.adapters.module_adapter.build_module_service_spec",
+            return_value=MagicMock(),
+        ),
+    ):
+        create_module_service_spec_from_metadata(
+            tmp_path,
+            module_name="fair-temperature",
+            module_type="temperature_module",
+            metadata=None,  # forces the load branch that constructs path from experiment_dir
+        )
+        mock_load.assert_called_once_with(tmp_path / "experiment-config.yaml")

--- a/tests/unit/test_module_loader.py
+++ b/tests/unit/test_module_loader.py
@@ -3,7 +3,7 @@ import pytest
 from facts_experiment_builder.infra.exceptions import ModuleYamlNotFoundError
 
 
-def load_facts_module_from_yaml_fails_with_false_path(
+def load_module_schema_from_yaml_fails_with_false_path(
     yaml_path="/Users/fake/path/to/module/yaml",
 ):
     assert pytest.raises(ModuleYamlNotFoundError)

--- a/tests/unit/test_registry_warnings.py
+++ b/tests/unit/test_registry_warnings.py
@@ -1,14 +1,15 @@
+import logging
 import subprocess
-import warnings
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from facts_experiment_builder.core.registry.module_registry import (
     _warn_if_registry_behind,
+    _warn_if_registry_dirty,
 )
 
 _PATCH = "facts_experiment_builder.core.registry.module_registry.subprocess.run"
+_LOGGER = "facts_experiment_builder.core.registry.module_registry"
 
 
 def _run(returncode=0, stdout=""):
@@ -20,51 +21,81 @@ def _run(returncode=0, stdout=""):
 # ---------------------------------------------------------------------------
 
 
-def test_no_warning_when_up_to_date(tmp_path):
-    with patch(_PATCH, side_effect=[_run(), _run(stdout="0")]):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+def test_no_warning_when_up_to_date(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=[_run(), _run(stdout="0")]):
             _warn_if_registry_behind(tmp_path)
-    assert len(w) == 0
+    assert len(caplog.records) == 0
 
 
-def test_warns_with_commit_count_when_behind(tmp_path):
-    with patch(_PATCH, side_effect=[_run(), _run(stdout="3")]):
-        with pytest.warns(UserWarning, match="3 commit\\(s\\) behind"):
+def test_warns_with_commit_count_when_behind(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=[_run(), _run(stdout="3")]):
             _warn_if_registry_behind(tmp_path)
+    assert any("3 commit(s) behind" in r.message for r in caplog.records)
 
 
-def test_warns_on_fetch_timeout(tmp_path):
-    with patch(_PATCH, side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5)):
-        with pytest.warns(UserWarning, match="Could not check"):
+def test_warns_on_fetch_timeout(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5)):
             _warn_if_registry_behind(tmp_path)
+    assert any("Could not check" in r.message for r in caplog.records)
 
 
-def test_warns_on_git_not_found(tmp_path):
-    with patch(_PATCH, side_effect=FileNotFoundError("git not found")):
-        with pytest.warns(UserWarning, match="Could not check"):
+def test_warns_on_git_not_found(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=FileNotFoundError("git not found")):
             _warn_if_registry_behind(tmp_path)
+    assert any("Could not check" in r.message for r in caplog.records)
 
 
-def test_warns_on_os_error(tmp_path):
-    with patch(_PATCH, side_effect=OSError("permission denied")):
-        with pytest.warns(UserWarning, match="Could not check"):
+def test_warns_on_os_error(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=OSError("permission denied")):
             _warn_if_registry_behind(tmp_path)
+    assert any("Could not check" in r.message for r in caplog.records)
 
 
-def test_no_warning_when_no_upstream_tracking_branch(tmp_path):
+def test_no_warning_when_no_upstream_tracking_branch(tmp_path, caplog):
     """rev-list returns non-zero when no upstream is configured — no warning."""
-    with patch(_PATCH, side_effect=[_run(), _run(returncode=128, stdout="")]):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, side_effect=[_run(), _run(returncode=128, stdout="")]):
             _warn_if_registry_behind(tmp_path)
-    assert len(w) == 0
+    assert len(caplog.records) == 0
 
 
-def test_rev_list_not_called_after_fetch_failure(tmp_path):
+def test_rev_list_not_called_after_fetch_failure(tmp_path, caplog):
     """If fetch raises, rev-list must not be called."""
     with patch(_PATCH, side_effect=FileNotFoundError("git not found")) as mock_run:
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
             _warn_if_registry_behind(tmp_path)
     mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _warn_if_registry_dirty
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_no_warning_when_clean(tmp_path, caplog):
+    """returncode=0, empty stdout → no warning."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, return_value=_run(stdout="")):
+            _warn_if_registry_dirty(tmp_path)
+    assert len(caplog.records) == 0
+
+
+def test_dirty_warns_when_uncommitted_changes(tmp_path, caplog):
+    """returncode=0, non-empty stdout → logger.warning fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, return_value=_run(stdout=" M some_file.yaml\n")):
+            _warn_if_registry_dirty(tmp_path)
+    assert any("uncommitted changes" in r.message for r in caplog.records)
+
+
+def test_dirty_no_warning_on_git_error(tmp_path, caplog):
+    """Non-zero returncode → no warning (git error treated as not-dirty)."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        with patch(_PATCH, return_value=_run(returncode=128, stdout="")):
+            _warn_if_registry_dirty(tmp_path)
+    assert len(caplog.records) == 0

--- a/tests/unit/test_setup_experiment.py
+++ b/tests/unit/test_setup_experiment.py
@@ -1,8 +1,10 @@
+import yaml
 from unittest.mock import patch
 from facts_experiment_builder.application.setup_experiment import (
     hydrate_experiment,
     hydrate_sealevel_step,
 )
+from facts_experiment_builder.infra.write_experiment_metadata import format_module_value
 from facts_experiment_builder.core.experiment.experiment_skeleton import (
     ExperimentSkeleton,
 )
@@ -333,3 +335,17 @@ def test_collect_metadata_param_keys_empty_when_no_metadata_sources():
     )
     result = collect_metadata_param_keys([schema], "fingerprint_params")
     assert result == {}
+
+
+def test_format_module_value_empty_dict_roundtrips_as_empty_dict():
+    """An empty dict value (e.g. outputs: {}) must serialise as 'key: {}' so YAML
+    reads it back as an empty dict rather than None.
+
+    Regression test for the bug where extremesealevel-pointsoverthreshold.outputs
+    (which has no outputs) was serialised as a bare 'outputs:' key, causing YAML
+    to parse it as None and the adapter to raise a ValueError.
+    """
+    lines = format_module_value("outputs", {})
+    rendered = "\n".join(lines)
+    parsed = yaml.safe_load(rendered)
+    assert parsed == {"outputs": {}}, f"Expected {{'outputs': {{}}}}, got: {parsed}"

--- a/tests/unit/test_setup_experiment.py
+++ b/tests/unit/test_setup_experiment.py
@@ -55,7 +55,7 @@ def test_hydrate_experiment_no_modules_returns_none_steps():
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_experiment_climate_module_produces_module_spec(mock_load):
     mock_load.return_value = make_module_schema("fair-temperature")
@@ -68,7 +68,7 @@ def test_hydrate_experiment_climate_module_produces_module_spec(mock_load):
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_experiment_totaling_module_produces_module_spec(mock_load):
     mock_load.return_value = make_module_schema("facts-total")
@@ -81,7 +81,7 @@ def test_hydrate_experiment_totaling_module_produces_module_spec(mock_load):
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_experiment_esl_module_produces_module_spec(mock_load):
     mock_load.return_value = make_module_schema("extremesealevel-pointsoverthreshold")
@@ -108,7 +108,7 @@ def test_hydrate_sealevel_step_no_modules_uses_supplied_totaled_sealevel_step_da
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_sealevel_step_loads_schemas_for_each_module(mock_load):
     mock_load.side_effect = [
@@ -125,7 +125,7 @@ def test_hydrate_sealevel_step_loads_schemas_for_each_module(mock_load):
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_sealevel_step_merges_climate_data_using_module_specific_input_key(
     mock_load,
@@ -171,7 +171,7 @@ def test_hydrate_sealevel_step_merges_climate_data_using_module_specific_input_k
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_sealevel_step_skips_merge_for_modules_without_climate_file(mock_load):
     mock_load.side_effect = [
@@ -193,7 +193,7 @@ def test_hydrate_sealevel_step_skips_merge_for_modules_without_climate_file(mock
 
 
 @patch(
-    "facts_experiment_builder.application.setup_experiment.load_facts_module_by_name"
+    "facts_experiment_builder.application.setup_experiment.load_module_schema_by_name"
 )
 def test_hydrate_sealevel_step_passes_top_level_context_to_specs(mock_load):
     """top_level_context (e.g. pyear_end) must reach ModuleExperimentSpec so

--- a/tests/unit/test_typed_paths.py
+++ b/tests/unit/test_typed_paths.py
@@ -3,7 +3,11 @@
 from facts_experiment_builder.core.typed_path import (
     TypedPath,
     HostPath,
+    HostDirPath,
     ContainerPath,
+)
+from facts_experiment_builder.adapters.experiment_metadata_to_service_spec import (
+    _dir_input_keys,
 )
 from facts_experiment_builder.core.module.module_service_spec import (
     ModuleServiceSpec,
@@ -18,7 +22,7 @@ from facts_experiment_builder.infra.path_utils import (
 
 
 def test_typed_path_construction():
-    """TypedPath, HostPath, ContainerPath have correct path and kind."""
+    """TypedPath, HostPath, ContainerPath, HostDirPath have correct path and kind."""
     tp = TypedPath(path="/mnt/out/a.nc", kind="container")
     assert tp.path == "/mnt/out/a.nc"
     assert tp.kind == "container"
@@ -30,6 +34,10 @@ def test_typed_path_construction():
     c = ContainerPath("/mnt/out/b.nc")
     assert c.path == "/mnt/out/b.nc"
     assert c.kind == "container"
+
+    d = HostDirPath("/host/path/cmip6/zos")
+    assert d.path == "/host/path/cmip6/zos"
+    assert d.kind == "host_dir"
 
 
 def test_container_path_list_pass_through():
@@ -220,3 +228,155 @@ def test_generate_compose_service_includes_environment():
     service = spec.generate_compose_service()
     assert "environment" in service
     assert "EMULANDICE_FORCING_HEAD_PATH" in service["environment"]
+
+
+def test_dir_input_keys_returns_keys_with_type_dir():
+    """_dir_input_keys returns field names for inputs declared type: 'dir'."""
+    module_def = ModuleSchema(
+        module_name="test-mod",
+        container_image="img:tag",
+        arguments={
+            "top_level": [],
+            "options": [],
+            "fingerprint_params": [],
+            "inputs": [
+                {
+                    "name": "zosdir",
+                    "type": "dir",
+                    "source": "module_inputs.inputs.zosdir",
+                    "mount": {
+                        "volume": "module_specific_in",
+                        "container_path": "/mnt/module_specific_in",
+                    },
+                },
+                {
+                    "name": "expansion-coefficients-file",
+                    "type": "file",
+                    "source": "module_inputs.inputs.expansion_coefficients_file",
+                    "mount": {
+                        "volume": "input",
+                        "container_path": "/mnt/module_specific_in",
+                    },
+                },
+                {
+                    "name": "seed",
+                    "type": "int",
+                    "source": "module_inputs.options.seed",
+                },
+            ],
+            "outputs": {},
+        },
+        volumes={},
+    )
+    keys = _dir_input_keys(module_def)
+    assert keys == {"zosdir"}
+
+
+def test_host_dir_path_gets_trailing_slash_in_command():
+    """A HostDirPath input produces a container path with a trailing slash."""
+    input_paths = build_module_input_paths(
+        module_specific_input_dir="/data/module-specific/ebm3-sterodynamics",
+        shared_input_dir="/data/shared",
+        module_name="ebm3-sterodynamics",
+    )
+    output_paths = build_module_output_paths(
+        "/data/output/ebm3-sterodynamics", "global", module_name="ebm3-sterodynamics"
+    )
+    components = ModuleServiceSpecComponents(
+        module_name="ebm3-sterodynamics",
+        options={},
+        input_paths=input_paths,
+        output_paths=output_paths,
+        fingerprint_params={},
+        inputs={
+            "zosdir": HostDirPath("/data/module-specific/ebm3-sterodynamics/cmip6/zos")
+        },
+        outputs={},
+        image=ModuleContainerImage(image_url="img", image_tag="tag"),
+        metadata={},
+        output_container_base=None,
+    )
+    module_def = ModuleSchema(
+        module_name="ebm3-sterodynamics",
+        container_image="img:tag",
+        arguments={
+            "top_level": [],
+            "options": [],
+            "fingerprint_params": [],
+            "inputs": [
+                {
+                    "name": "zosdir",
+                    "type": "dir",
+                    "source": "module_inputs.inputs.zosdir",
+                    "mount": {
+                        "volume": "module_specific_in",
+                        "container_path": "/mnt/module_specific_in",
+                    },
+                }
+            ],
+            "outputs": {},
+        },
+        volumes={},
+    )
+    spec = ModuleServiceSpec(components=components, module_definition=module_def)
+    command = spec._build_command_args()
+    zosdir_arg = next((a for a in command if a.startswith("--zosdir=")), None)
+    assert zosdir_arg is not None
+    assert zosdir_arg.endswith("/"), f"Expected trailing slash, got: {zosdir_arg}"
+
+
+def test_host_path_does_not_get_trailing_slash_in_command():
+    """A regular HostPath input does not have a trailing slash added."""
+    input_paths = build_module_input_paths(
+        module_specific_input_dir="/data/module-specific/test-mod",
+        shared_input_dir="/data/shared",
+        module_name="test-mod",
+    )
+    output_paths = build_module_output_paths(
+        "/data/output/test-mod", "global", module_name="test-mod"
+    )
+    components = ModuleServiceSpecComponents(
+        module_name="test-mod",
+        options={},
+        input_paths=input_paths,
+        output_paths=output_paths,
+        fingerprint_params={},
+        inputs={
+            "expansion_coefficients_file": HostPath(
+                "/data/module-specific/test-mod/coefs.nc"
+            )
+        },
+        outputs={},
+        image=ModuleContainerImage(image_url="img", image_tag="tag"),
+        metadata={},
+        output_container_base=None,
+    )
+    module_def = ModuleSchema(
+        module_name="test-mod",
+        container_image="img:tag",
+        arguments={
+            "top_level": [],
+            "options": [],
+            "fingerprint_params": [],
+            "inputs": [
+                {
+                    "name": "expansion-coefficients-file",
+                    "type": "file",
+                    "source": "module_inputs.inputs.expansion_coefficients_file",
+                    "mount": {
+                        "volume": "input",
+                        "container_path": "/mnt/module_specific_in",
+                    },
+                }
+            ],
+            "outputs": {},
+        },
+        volumes={},
+    )
+    spec = ModuleServiceSpec(components=components, module_definition=module_def)
+    command = spec._build_command_args()
+    file_arg = next(
+        (a for a in command if a.startswith("--expansion-coefficients-file=")), None
+    )
+    assert file_arg is not None
+    assert not file_arg.endswith("/"), f"Did not expect trailing slash, got: {file_arg}"


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->
This PR addresses a number of issues:
1. previously, the git checks to see the status of the local module registry used in feb were called for every module in an experiment when `feb setup-experiment` was called. this meant that the same warnings were printed multiple times. 
- This PR caches the module registry for the duration of the command so that the checks are only run once
- Also, splits previous function that warned if the registry was out of day -- there are now separate `_check_if_registry_behind()` and `_warn_if_module_behind()` fns

2. Adds a new type option to input entries in a module's module yaml. type can now be "dir" (for things like `model-dir` in tlm-sterodynaimcs, ebm3...). Fixes a bug related to trailing / being dropped from these paths specified by input dirs and allows for new `TypedPath`, `HostDirPath` in FEB. This differentiates from `HostPath`, which is used when i full path including file name is passed as an input arg. 

3. Rename `load_facts_module_by_name()` and `load_facts_module_from_yaml()` to -> `load_module_schema_by_name()` and `load_module_schema_from_yaml()`. more accurate naming

4. Significant refactoring of `generate_compose()`. This was pretty poorly written before, is now broken into more logical smaller functions to be more testable

5. Previously, `application.generate_compose()` printed some warning/status messages. These are now all passed to `cli.generate_compose_cli` and handled there. `_ClickEchoHandler()` is connected to feb namespace logger and prints formatted messagse from logs. Also, will now fail if a services is unable to be created in generate_compose(). Before, would fail silently and still write a compose just missing the failed service. 

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [x] Bug fix
- [ ] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [x] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [x] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...
Claude was used at various points, reviewed before adding


## Checklist
- [x] Code runs without errors locally
- [x] Tests added or updated (if applicable)
- [x] Existing tests pass
- [x] Data inputs/outputs are documented or unchanged
- [x] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)