### PR TITLE
update zenodo record used for fair2 data

### DIFF
--- a/docs/module_input_data_downloads.md
+++ b/docs/module_input_data_downloads.md
@@ -38,7 +38,7 @@ tar -xzf data/module_specific_input_data/fair-temperature/fair_temperature_prepr
 
 ```bash
 mkdir -p data/module_specific_input_data/fair2-climate
-curl -L https://zenodo.org/records/11506798/files/fair2_climate_project_data.tgz -o data/module_specific_input_data/fair2-climate/fair2_climate_project_data.tgz
+curl -L https://zenodo.org/records/18190680/files/fair2_climate_project_data.tgz -o data/module_specific_input_data/fair2-climate/fair2_climate_project_data.tgz
 tar -xzf data/module_specific_input_data/fair2-climate/fair2_climate_project_data.tgz -C data/module_specific_input_data/fair2-climate
 ```
 

--- a/docs/module_input_data_downloads.md
+++ b/docs/module_input_data_downloads.md
@@ -136,6 +136,7 @@ tar -xzf data/module_specific_input_data/kopp14-verticallandmotion/kopp14_vertic
 mkdir -p data/module_specific_input_data/oelsmann24-verticallandmotion
 curl -L https://zenodo.org/records/18199757/files/oelsmann24_vlm_data.tar.gz -o data/module_specific_input_data/oelsmann24-verticallandmotion/oelsmann24_vlm_data.tar.gz
 tar -xzf data/module_specific_input_data/oelsmann24-verticallandmotion/oelsmann24_vlm_data.tar.gz -C data/module_specific_input_data/oelsmann24-verticallandmotion
+mv data/module_specific_input_data/oelsmann24-verticallandmotion/data/* data/module_specific_input_data/oelsmann24-verticallandmotion/ && rmdir data/module_specific_input_data/oelsmann24-verticallandmotion/data
 ```
 
 ### nzinsargps-verticallandmotion

--- a/src/facts_experiment_builder/application/check_data.py
+++ b/src/facts_experiment_builder/application/check_data.py
@@ -265,32 +265,12 @@ def _check_module(
     fp_file_checks = [execute_check(plan, module_input_dir) for plan in fp_plans]
 
     combined_file_checks = input_file_checks + fp_file_checks
-    print("Number of entries in this module: ", len(combined_file_checks))
-    print(
-        f"this includes {len(input_file_checks)} from inputs section \n and {len(fp_file_checks)} from FP params section! "
-    )
 
-    # num_skipped = sum(1 for c in combined_file_checks if not c.skipped and c.exists)
     skipped_checks = []
     for check in combined_file_checks:
         if check.skipped is True:
             skipped_checks.append(check.field_name)
-    num_skipped = len(skipped_checks)
-    print("num skipped : ", num_skipped)
-    for c in combined_file_checks:
-        if c.skipped:
-            print(f"{c.field_name} is showing as skipped.")
 
-    for check in combined_file_checks:
-        print(f"Checking {check.field_name}....")
-        if check.skip_reason != "":
-            print("This input was skipped in checks because:")
-            print("Skip reason: ", check.skip_reason)
-        else:
-            print("This input wasnt skipped. Expected path is: ")
-            print(check.expected_path)
-    print("--")
-    print("")
     return combined_file_checks  # , skipped_checks
 
 


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->
This PR:
- updates the module data download instructions to use the current Zenodo record to download data for fair2-climate module. 
- Adds some directory cleanup necessary in the download instructions for oelsmann24-verticallandmotion input data
- removes some print statements that were left in `check-data` from last PR 

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [ ] Refactor / cleanup
- [x] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [ ] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...



## Checklist
- [ ] Code runs without errors locally
- [ ] Tests added or updated (if applicable)
- [ ] Existing tests pass
- [ ] Data inputs/outputs are documented or unchanged
- [ ] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)