### PR TITLE
Add experiment repository

### DIFF
--- a/src/facts_experiment_builder/application/check_data.py
+++ b/src/facts_experiment_builder/application/check_data.py
@@ -16,10 +16,7 @@ from facts_experiment_builder.core.typed_path import (
     _MODULE_SPECIFIC_CONTAINER_PATH,
 )
 
-# ---------------------- IO imports ----------------------------
-from facts_experiment_builder.io.module_registry import (
-    ModuleRegistry,
-)
+from facts_experiment_builder.application.storage import ModuleRegistry
 
 
 @dataclass

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -24,10 +24,13 @@ from facts_experiment_builder.core.workflow import (
     Workflow,
 )
 
+from facts_experiment_builder.application.storage import (
+    ExperimentRepository,
+    ModuleRegistry,
+)
+
 # ---------------------- IO imports ----------------------------
 from facts_experiment_builder.io.paths import ExperimentPaths
-from facts_experiment_builder.io.module_registry import ModuleRegistry
-from facts_experiment_builder.io.experiment_repository import ExperimentRepository
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -26,10 +26,8 @@ from facts_experiment_builder.core.workflow import (
 
 # ---------------------- IO imports ----------------------------
 from facts_experiment_builder.io.paths import ExperimentPaths
-
-from facts_experiment_builder.io.experiment_loader import (
-    load_experiment_config,
-)
+from facts_experiment_builder.io.module_registry import ModuleRegistry
+from facts_experiment_builder.io.experiment_repository import ExperimentRepository
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -554,7 +552,8 @@ def _build_compose_services(
 def generate_compose(
     experiment_name: str,
     workspace_dir: Path,
-    definition,
+    module_registry: ModuleRegistry,
+    experiment_repo: ExperimentRepository,
     custom_compose_path: Path | None = None,
 ) -> Dict[str, Any]:
     """Generate Docker Compose dict from already-loaded experiment metadata.
@@ -576,7 +575,7 @@ def generate_compose(
     )
     experiment_paths.custom_compose_path = custom_compose_path
 
-    # handle custom compose, if passed
+    # handle custom compose, if passed -- is this still necessary?
     compose_path = (
         experiment_paths.custom_compose_path.resolve()
         if experiment_paths.custom_compose_path is not None
@@ -597,11 +596,14 @@ def generate_compose(
         "Found experiment config file at provided path", extra={"detail": config_path}
     )
 
-    metadata_dict = load_experiment_config(experiment_paths.config_path)
+    metadata_dict = experiment_repo.get(config_path=config_path)
+    # metadata_dict = load_experiment_config(experiment_paths.config_path)
     #  setup - only references to definition are here
     module_names = _extract_all_module_names_from_manifest(metadata_dict)
-    schemas = {m_name: definition.get_schema(m_name) for m_name in set(module_names)}
-    known_module_names = definition.module_names()
+    schemas = {
+        m_name: module_registry.get_schema(m_name) for m_name in set(module_names)
+    }
+    known_module_names = module_registry.module_names()
 
     # Make experiment plan
     plan = _make_experiment_plan(metadata_dict, schemas)

--- a/src/facts_experiment_builder/application/setup_experiment.py
+++ b/src/facts_experiment_builder/application/setup_experiment.py
@@ -23,10 +23,13 @@ from facts_experiment_builder.core.experiment.name import (
 )
 
 from facts_experiment_builder.io.paths import ExperimentPaths, make_output_dir
-from facts_experiment_builder.io.experiment_repository import (
+
+
+from facts_experiment_builder.application.storage import (
     ExperimentRepository,
+    ModuleRegistry,
 )
-from facts_experiment_builder.io.module_registry import ModuleRegistry
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/facts_experiment_builder/application/setup_experiment.py
+++ b/src/facts_experiment_builder/application/setup_experiment.py
@@ -16,26 +16,18 @@ from facts_experiment_builder.core.experiment.skeleton import (
 from facts_experiment_builder.core.experiment.skeleton import (
     experiment_skeleton_to_facts_experiment,
 )
-from facts_experiment_builder.core.module.module_definition_source import (
-    ModuleDefinitionSource,
-)
-from facts_experiment_builder.core.experiment.experiment_config import (
-    facts_experiment_to_config,
-)
 
 # --------------- IO imports --------------
 from facts_experiment_builder.core.experiment.name import (
     ExperimentName,
 )
-from facts_experiment_builder.io.write_config import write_config_jinja2
 
 from facts_experiment_builder.io.paths import ExperimentPaths, make_output_dir
 from facts_experiment_builder.io.experiment_repository import (
     ExperimentRepository,
 )
-from facts_experiment_builder.io.module_registry import (
-    ModuleRegistry
-)
+from facts_experiment_builder.io.module_registry import ModuleRegistry
+
 logger = logging.getLogger(__name__)
 
 
@@ -130,7 +122,7 @@ def finalize_experiment_setup(
     shared_input_data: str,
     projection_scale: str,
     module_registry: ModuleRegistry,
-    experiment_repo: ExperimentRepository
+    experiment_repo: ExperimentRepository,
 ) -> Path:
     """Complete an experiment setup and writes its configuration metadata to disk.
 
@@ -227,12 +219,13 @@ def finalize_experiment_setup(
         projection_scale=projection_scale,
         schemas=schemas,
     )
-    #make config path
+    # make config path
     config_path = experiment_paths.config_path
 
     experiment_repo.add(
         experiment=experiment_obj,
-        config_path = config_path,
-        module_registry_version = version)
+        config_path=config_path,
+        module_registry_version=version,
+    )
 
     return config_path

--- a/src/facts_experiment_builder/application/setup_experiment.py
+++ b/src/facts_experiment_builder/application/setup_experiment.py
@@ -30,7 +30,12 @@ from facts_experiment_builder.core.experiment.name import (
 from facts_experiment_builder.io.write_config import write_config_jinja2
 
 from facts_experiment_builder.io.paths import ExperimentPaths, make_output_dir
-
+from facts_experiment_builder.io.experiment_repository import (
+    ExperimentRepository,
+)
+from facts_experiment_builder.io.module_registry import (
+    ModuleRegistry
+)
 logger = logging.getLogger(__name__)
 
 
@@ -124,7 +129,8 @@ def finalize_experiment_setup(
     module_specific_input_data: str,
     shared_input_data: str,
     projection_scale: str,
-    definition: ModuleDefinitionSource,
+    module_registry: ModuleRegistry,
+    experiment_repo: ExperimentRepository
 ) -> Path:
     """Complete an experiment setup and writes its configuration metadata to disk.
 
@@ -162,9 +168,9 @@ def finalize_experiment_setup(
         Path to input data shared across modules
     projection_scale : str
         Indicates whether this experiment generates global (GMSL) or local (RSL) projections of sea level change.
-    definition : ModuleDefinitionSource
+    module_registry : ModuleRegistry
         Source of module metadata. Queried for the module registry version and schema of each module named in ``experiment_skeleton``.
-
+    experiment_repo: ExperimentRepository
     Returns
     -------
     Path
@@ -182,9 +188,9 @@ def finalize_experiment_setup(
     ``None`` entries dropped, so an experiment supplying neither yields an empty list.
     """
     # Gather info from port
-    version = definition.version()
+    version = module_registry.version()
     schemas = {
-        m: definition.get_schema(m) for m in experiment_skeleton.all_module_names
+        m: module_registry.get_schema(m) for m in experiment_skeleton.all_module_names
     }
     # make TopLevelParams dataclass
     top_level_params = TopLevelParams(
@@ -221,12 +227,12 @@ def finalize_experiment_setup(
         projection_scale=projection_scale,
         schemas=schemas,
     )
-    # Write config file using templtae
+    #make config path
     config_path = experiment_paths.config_path
-    experiment_config = facts_experiment_to_config(
-        experiment_obj=experiment_obj,
-        module_registry_version=version,
-    )
 
-    write_config_jinja2(experiment_config=experiment_config, config_path=config_path)
+    experiment_repo.add(
+        experiment=experiment_obj,
+        config_path = config_path,
+        module_registry_version = version)
+
     return config_path

--- a/src/facts_experiment_builder/application/storage.py
+++ b/src/facts_experiment_builder/application/storage.py
@@ -1,0 +1,22 @@
+"""Protocols (ports) describing the interfaces the application expects to interact with
+storage."""
+
+from typing import Protocol
+
+from facts_experiment_builder.core.module.module_schema import ModuleSchema
+from facts_experiment_builder.core.experiment.experiment import FactsExperiment
+
+
+class ModuleRegistry(Protocol):
+    """Protocol to access module registry data from storage."""
+
+    def get_schema(self, module_name: str) -> ModuleSchema: ...
+    def module_names(self) -> frozenset[str]: ...
+    def version(self) -> str: ...
+
+
+class ExperimentRepository(Protocol):
+    """Protocol to add/get facts experiments from storage."""
+
+    def add(self, experiment: FactsExperiment) -> None: ...
+    def get(self, name) -> FactsExperiment: ...

--- a/src/facts_experiment_builder/cli/generate_compose_cli.py
+++ b/src/facts_experiment_builder/cli/generate_compose_cli.py
@@ -19,6 +19,9 @@ from facts_experiment_builder.io.write_compose import (
     make_compose_yaml,
     write_compose_yaml,
 )
+from facts_experiment_builder.io.experiment_repository import (
+    StorageExperimentRepository,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,9 +98,11 @@ def main(
 ) -> None:
     """Generate Docker Compose file from experiment metadata."""
     _configure_feb_logging()
-    module_registry_path = module_registry.absolute()
-    registry = FileSystemModuleRegistry(registry_path=module_registry_path)
 
+    module_registry_path = module_registry.absolute()
+    # Instantiate adapters
+    registry = FileSystemModuleRegistry(registry_path=module_registry_path)
+    experiment_repo = StorageExperimentRepository()
     if debug:
         logger.setLevel(logging.INFO)
 
@@ -130,7 +135,8 @@ def main(
         output = generate_compose(
             experiment_name=experiment_name,
             workspace_dir=workspace_dir,
-            definition=registry,
+            module_registry=registry,
+            experiment_repo=experiment_repo,
             custom_compose_path=custom_compose_path,
         )
         compose_dict = output.compose_dict

--- a/src/facts_experiment_builder/cli/setup_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_experiment_cli.py
@@ -39,6 +39,9 @@ from facts_experiment_builder.application.setup_experiment import (
 # ---------------------- IO imports ----------------------------
 from facts_experiment_builder.io.module_registry import FileSystemModuleRegistry
 from facts_experiment_builder.io.paths import ExperimentPaths
+from facts_experiment_builder.io.experiment_repository import (
+    StorageExperimentRepository,
+)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
@@ -203,8 +206,7 @@ def main(
     module_registry_path = module_registry.absolute()
     registry = FileSystemModuleRegistry(registry_path=module_registry_path)
     valid_module_names = registry.module_names()
-    # storage = FileSystemExperimentStorage(workspace_dir)
-
+    experiment_repository = StorageExperimentRepository()
     console.rule(
         characters="- - ",
         style="rule",
@@ -287,7 +289,8 @@ def main(
         module_specific_input_data=module_specific_input_data,
         shared_input_data=shared_input_data,
         projection_scale=projection_scale,
-        definition=registry,  # registry passed as protocol
+        module_registry=registry,  # registry passed as protocol
+        experiment_repo=experiment_repository
     )
 
     print_experiment_directory_created(experiment_name, path_obj)

--- a/src/facts_experiment_builder/cli/setup_experiment_cli.py
+++ b/src/facts_experiment_builder/cli/setup_experiment_cli.py
@@ -290,7 +290,7 @@ def main(
         shared_input_data=shared_input_data,
         projection_scale=projection_scale,
         module_registry=registry,  # registry passed as protocol
-        experiment_repo=experiment_repository
+        experiment_repo=experiment_repository,
     )
 
     print_experiment_directory_created(experiment_name, path_obj)

--- a/src/facts_experiment_builder/io/experiment_repository.py
+++ b/src/facts_experiment_builder/io/experiment_repository.py
@@ -1,4 +1,3 @@
-from typing import Protocol
 from pathlib import Path
 
 # ---------------------- Core imports ----------------------------
@@ -13,17 +12,6 @@ from facts_experiment_builder.io.experiment_loader import (
     load_experiment_config,
 )
 from facts_experiment_builder.io.write_config import write_config_jinja2
-
-
-# port
-class ExperimentRepository(Protocol):
-    """Port where experiment config metadata dicts returned from.
-
-    Application code should depend on this instead of load_experiment_config() directly?
-    """
-
-    def add(self, experiment: FactsExperiment) -> None: ...
-    def get(self, name) -> FactsExperiment: ...
 
 
 # adapter

--- a/src/facts_experiment_builder/io/module_registry.py
+++ b/src/facts_experiment_builder/io/module_registry.py
@@ -2,23 +2,10 @@ from pathlib import Path
 import subprocess
 from pydantic import ValidationError
 import yaml
-from typing import Protocol
 
 # ---------------------- Core imports ----------------------------
 from facts_experiment_builder.core.module.module_schema import ModuleSchema
 from facts_experiment_builder.io.exceptions import ModuleYamlNotFoundError
-
-
-# This is the port
-class ModuleRegistry(Protocol):
-    """Port where module definitions come from.
-
-    application code depends on this class.
-    """
-
-    def get_schema(self, module_name: str) -> ModuleSchema: ...
-    def module_names(self) -> frozenset[str]: ...
-    def version(self) -> str: ...
 
 
 class ModuleRegistryNotFound(Exception):

--- a/tests/unit/test_setup_experiment.py
+++ b/tests/unit/test_setup_experiment.py
@@ -11,13 +11,15 @@ from facts_experiment_builder.core.module.module_schema import (
 from facts_experiment_builder.core.experiment.skeleton import (
     hydrate_experiment,
 )
-
-from facts_experiment_builder.io.write_config import format_module_value
 from facts_experiment_builder.core.experiment.skeleton import (
     ExperimentSkeleton,
 )
 from facts_experiment_builder.core.module.module_schema import (
     ModuleSchema,
+)
+from facts_experiment_builder.io.write_config import format_module_value
+from facts_experiment_builder.io.experiment_repository import (
+    StorageExperimentRepository,
 )
 from tests.unit.helpers import InMemoryModuleDefinitions
 
@@ -83,6 +85,7 @@ def test_finalize_experiment_setup_writes_metadata_config(tmp_path):
     workspace_dir = Path(tmp_path / "fake_experiment_location")
     workspace_dir.mkdir()
 
+    repo = StorageExperimentRepository()
     definitions = InMemoryModuleDefinitions(
         {
             "fair-temperature": make_schema("fair-temperature"),
@@ -123,7 +126,8 @@ def test_finalize_experiment_setup_writes_metadata_config(tmp_path):
         module_specific_input_data="path/to/data",
         shared_input_data="path/to/shared/data",
         projection_scale="local",
-        definition=definitions,
+        module_registry=definitions,
+        experiment_repo=repo,
     )
     config_path = experiment_path.config_path
     assert config_path.exists()


### PR DESCRIPTION
## Description
<!-- Summarize what changed and why. Include relevant context (e.g. new model, updated pipeline, data changes). -->
This PR adds a port and adapter to represent an experiment repository. It uses this object's .`add()`, `.get()` methods in `setup-experiment` and `generate-compose` in place of the previous functions to write and read experiment config files

## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #


## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [ ] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [ ] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...



## Checklist
- [ ] Code runs without errors locally
- [ ] Tests added or updated (if applicable)
- [ ] Existing tests pass
- [ ] Data inputs/outputs are documented or unchanged
- [ ] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)