### PR TITLE
Move storage protocols to application

### DIFF
--- a/src/facts_experiment_builder/application/check_data.py
+++ b/src/facts_experiment_builder/application/check_data.py
@@ -16,10 +16,7 @@ from facts_experiment_builder.core.typed_path import (
     _MODULE_SPECIFIC_CONTAINER_PATH,
 )
 
-# ---------------------- IO imports ----------------------------
-from facts_experiment_builder.io.module_registry import (
-    ModuleRegistry,
-)
+from facts_experiment_builder.application.storage import ModuleRegistry
 
 
 @dataclass

--- a/src/facts_experiment_builder/application/generate_compose.py
+++ b/src/facts_experiment_builder/application/generate_compose.py
@@ -24,10 +24,13 @@ from facts_experiment_builder.core.workflow import (
     Workflow,
 )
 
+from facts_experiment_builder.application.storage import (
+    ExperimentRepository,
+    ModuleRegistry,
+)
+
 # ---------------------- IO imports ----------------------------
 from facts_experiment_builder.io.paths import ExperimentPaths
-from facts_experiment_builder.io.module_registry import ModuleRegistry
-from facts_experiment_builder.io.experiment_repository import ExperimentRepository
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/facts_experiment_builder/application/setup_experiment.py
+++ b/src/facts_experiment_builder/application/setup_experiment.py
@@ -23,10 +23,13 @@ from facts_experiment_builder.core.experiment.name import (
 )
 
 from facts_experiment_builder.io.paths import ExperimentPaths, make_output_dir
-from facts_experiment_builder.io.experiment_repository import (
+
+
+from facts_experiment_builder.application.storage import (
     ExperimentRepository,
+    ModuleRegistry,
 )
-from facts_experiment_builder.io.module_registry import ModuleRegistry
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/facts_experiment_builder/application/storage.py
+++ b/src/facts_experiment_builder/application/storage.py
@@ -1,0 +1,22 @@
+"""Protocols (ports) describing the interfaces the application expects to interact with
+storage."""
+
+from typing import Protocol
+
+from facts_experiment_builder.core.module.module_schema import ModuleSchema
+from facts_experiment_builder.core.experiment.experiment import FactsExperiment
+
+
+class ModuleRegistry(Protocol):
+    """Protocol to access module registry data from storage."""
+
+    def get_schema(self, module_name: str) -> ModuleSchema: ...
+    def module_names(self) -> frozenset[str]: ...
+    def version(self) -> str: ...
+
+
+class ExperimentRepository(Protocol):
+    """Protocol to add/get facts experiments from storage."""
+
+    def add(self, experiment: FactsExperiment) -> None: ...
+    def get(self, name) -> FactsExperiment: ...

--- a/src/facts_experiment_builder/io/experiment_repository.py
+++ b/src/facts_experiment_builder/io/experiment_repository.py
@@ -1,4 +1,3 @@
-from typing import Protocol
 from pathlib import Path
 
 # ---------------------- Core imports ----------------------------
@@ -13,17 +12,6 @@ from facts_experiment_builder.io.experiment_loader import (
     load_experiment_config,
 )
 from facts_experiment_builder.io.write_config import write_config_jinja2
-
-
-# port
-class ExperimentRepository(Protocol):
-    """Port where experiment config metadata dicts returned from.
-
-    Application code should depend on this instead of load_experiment_config() directly?
-    """
-
-    def add(self, experiment: FactsExperiment) -> None: ...
-    def get(self, name) -> FactsExperiment: ...
 
 
 # adapter

--- a/src/facts_experiment_builder/io/module_registry.py
+++ b/src/facts_experiment_builder/io/module_registry.py
@@ -2,23 +2,10 @@ from pathlib import Path
 import subprocess
 from pydantic import ValidationError
 import yaml
-from typing import Protocol
 
 # ---------------------- Core imports ----------------------------
 from facts_experiment_builder.core.module.module_schema import ModuleSchema
 from facts_experiment_builder.io.exceptions import ModuleYamlNotFoundError
-
-
-# This is the port
-class ModuleRegistry(Protocol):
-    """Port where module definitions come from.
-
-    application code depends on this class.
-    """
-
-    def get_schema(self, module_name: str) -> ModuleSchema: ...
-    def module_names(self) -> frozenset[str]: ...
-    def version(self) -> str: ...
 
 
 class ModuleRegistryNotFound(Exception):


### PR DESCRIPTION
## Description
This moves the storage/repository protocols from io to the application layer. This stresses the importance of having the application/business needs drive the protocol rather than infrastructure details.

More concretely, the io `ModuleRegistry` and `ExperimentRepository` protocols got moved to a new `src/facts_experiment_builder/application/storage.py` module from `src/facts_experiment_builder/io/experiment_repository.py` and `src/facts_experiment_builder/io/module_registry.py`.

This is to demonstrate this as part of a broader design discussion about managing complexity and ports + adapters -- rather than having implementation details smeared across the broader application. It's also more of a common pattern or principle rather than a hard rule.


## Related Issues / Tickets
<!-- Link any related issues, tickets, or discussions. -->
- Closes #
- Related to #109


## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [x] New feature / experiment
- [ ] Data pipeline change
- [ ] Model / algorithm update
- [ ] Refactor / cleanup
- [ ] Documentation update


## Breaking Changes
<!-- Does this PR introduce any breaking changes? If yes, describe what breaks and how to migrate. -->
- [ ] Yes — describe below
- [x] No

> _Breaking change details (if applicable):_


## Screenshots / Visualizations
<!-- If relevant, include plots, metric comparisons, sample outputs, or before/after visuals. -->


## Gen AI
Was generative AI used in any part of this PR? If so, describe...

Nope.


## Checklist
- [ ] Code runs without errors locally
- [x] Tests added or updated (if applicable)
- [x] Existing tests pass
- [ ] Data inputs/outputs are documented or unchanged
- [ ] No hardcoded paths, credentials, or environment-specific values
- [ ] Relevant docs / README updated
- [ ] Results are reproducible (seed set, environment pinned, etc.)